### PR TITLE
fix: require instructor auth for presentation view

### DIFF
--- a/packages/client/src/App.tsx
+++ b/packages/client/src/App.tsx
@@ -16,6 +16,42 @@ const INSTRUCTOR_ROUTE_SEGMENT = normalizeRouteSegment(
 );
 const INSTRUCTOR_HASH_ROUTE = `/${INSTRUCTOR_ROUTE_SEGMENT}`;
 
+type AppPage = "home" | "instructor" | "join" | "student" | "presentation";
+type AuthContext = "presentation";
+
+interface AppRoute {
+  page: AppPage;
+  param?: string;
+  next?: string;
+  authContext?: AuthContext;
+}
+
+function sanitizeHashPath(value?: string | null): string | undefined {
+  const trimmed = (value || "").trim();
+  if (!trimmed.startsWith("/") || trimmed.startsWith("//")) return undefined;
+  return trimmed;
+}
+
+function navigateToHashPath(path: string): void {
+  window.location.hash = path;
+}
+
+function buildInstructorLoginHash(options: { next?: string; authContext?: AuthContext } = {}): string {
+  const params = new URLSearchParams();
+  const next = sanitizeHashPath(options.next);
+
+  if (next) {
+    params.set("next", next);
+  }
+
+  if (options.authContext) {
+    params.set("context", options.authContext);
+  }
+
+  const query = params.toString();
+  return `#${INSTRUCTOR_HASH_ROUTE}${query ? `?${query}` : ""}`;
+}
+
 /**
  * Simple hash-based routing:
  *   /             -> role picker (instructor or student)
@@ -24,12 +60,21 @@ const INSTRUCTOR_HASH_ROUTE = `/${INSTRUCTOR_ROUTE_SEGMENT}`;
  *   /s/:sessionId -> student in-session (after join)
  *   /present/:id  -> read-only projector view for an active session
  */
-function getRoute(): { page: string; param?: string } {
+function getRoute(): AppRoute {
   const hash = window.location.hash.replace(/^#/, "");
-  if (hash === INSTRUCTOR_HASH_ROUTE || hash === `${INSTRUCTOR_HASH_ROUTE}/`) return { page: "instructor" };
-  if (hash.startsWith("/join/")) return { page: "join", param: hash.split("/")[2] };
-  if (hash.startsWith("/s/")) return { page: "student", param: hash.split("/")[2] };
-  if (hash.startsWith("/present/")) return { page: "presentation", param: hash.split("/")[2] };
+  const [path, queryString = ""] = hash.split("?");
+  const params = new URLSearchParams(queryString);
+
+  if (path === INSTRUCTOR_HASH_ROUTE || path === `${INSTRUCTOR_HASH_ROUTE}/`) {
+    return {
+      page: "instructor",
+      next: sanitizeHashPath(params.get("next")),
+      authContext: params.get("context") === "presentation" ? "presentation" : undefined,
+    };
+  }
+  if (path.startsWith("/join/")) return { page: "join", param: path.split("/")[2] };
+  if (path.startsWith("/s/")) return { page: "student", param: path.split("/")[2] };
+  if (path.startsWith("/present/")) return { page: "presentation", param: path.split("/")[2] };
   return { page: "home" };
 }
 
@@ -43,7 +88,7 @@ export default function App() {
   }, []);
 
   if (route.page === "instructor") {
-    return <InstructorGate />;
+    return <InstructorGate returnTo={route.next} authContext={route.authContext} />;
   }
 
   if (route.page === "join") {
@@ -55,7 +100,15 @@ export default function App() {
   }
 
   if (route.page === "presentation" && route.param) {
-    return <PresentationView sessionId={route.param} />;
+    return (
+      <PresentationView
+        sessionId={route.param}
+        loginHref={buildInstructorLoginHash({
+          next: `/present/${route.param}`,
+          authContext: "presentation",
+        })}
+      />
+    );
   }
 
   // Home: role picker
@@ -92,7 +145,7 @@ export default function App() {
   );
 }
 
-function InstructorGate() {
+function InstructorGate({ returnTo, authContext }: { returnTo?: string; authContext?: AuthContext }) {
   const [checking, setChecking] = useState(true);
   const [authenticated, setAuthenticated] = useState(false);
   const [password, setPassword] = useState("");
@@ -110,6 +163,12 @@ function InstructorGate() {
       .finally(() => setChecking(false));
   }, []);
 
+  useEffect(() => {
+    if (!checking && authenticated && returnTo) {
+      navigateToHashPath(returnTo);
+    }
+  }, [authenticated, checking, returnTo]);
+
   if (checking) {
     return (
       <div className="min-h-dvh flex items-center justify-center p-6 text-zinc-300">
@@ -118,9 +177,28 @@ function InstructorGate() {
     );
   }
 
+  if (authenticated && returnTo) {
+    return (
+      <div className="min-h-dvh flex items-center justify-center p-6 text-zinc-300">
+        Opening presentation view...
+      </div>
+    );
+  }
+
   if (authenticated) {
     return <InstructorView />;
   }
+
+  const isPresentationLogin = authContext === "presentation";
+  const title = isPresentationLogin ? "Instructor Login Required" : "Instructor Login";
+  const description = isPresentationLogin
+    ? "Presentation mode is protected when the instructor password is enabled. Sign in and you will return to the presenter view."
+    : "Enter the instructor password to access session controls.";
+  const submitLabel = submitting
+    ? "Signing in..."
+    : isPresentationLogin
+      ? "Sign In to Open Presentation"
+      : "Sign In";
 
   async function handleSubmit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
@@ -128,8 +206,12 @@ function InstructorGate() {
     setError(null);
     try {
       await loginInstructor(password);
-      setAuthenticated(true);
       setPassword("");
+      if (returnTo) {
+        navigateToHashPath(returnTo);
+        return;
+      }
+      setAuthenticated(true);
     } catch (e) {
       setError(e instanceof Error ? e.message : "Login failed");
     } finally {
@@ -141,8 +223,8 @@ function InstructorGate() {
     <div className="min-h-dvh flex flex-col items-center justify-center gap-8 p-6">
       <div className="w-full max-w-md space-y-6">
         <div className="text-center space-y-2">
-          <h1 className="text-3xl font-bold text-white">Instructor Login</h1>
-          <p className="text-zinc-400">Enter the instructor password to access session controls.</p>
+          <h1 className="text-3xl font-bold text-white">{title}</h1>
+          <p className="text-zinc-400">{description}</p>
         </div>
 
         <form onSubmit={handleSubmit} className="space-y-4">
@@ -166,7 +248,7 @@ function InstructorGate() {
             disabled={submitting || !password}
             className="w-full bg-indigo-600 hover:bg-indigo-500 disabled:bg-zinc-700 disabled:text-zinc-500 text-white font-semibold py-3 rounded-xl transition-colors"
           >
-            {submitting ? "Signing in..." : "Sign In"}
+            {submitLabel}
           </button>
         </form>
 
@@ -174,8 +256,8 @@ function InstructorGate() {
           <a href="#/" className="text-zinc-400 hover:text-zinc-200">
             Back home
           </a>
-          <a href="#/join/" className="text-zinc-400 hover:text-zinc-200">
-            Go to quiz join
+          <a href={`#${INSTRUCTOR_HASH_ROUTE}`} className="text-zinc-400 hover:text-zinc-200">
+            Instructor controls
           </a>
         </div>
       </div>

--- a/packages/client/src/App.tsx
+++ b/packages/client/src/App.tsx
@@ -1,8 +1,9 @@
-import { useState, useEffect, type FormEvent } from "react";
+import { useState, useEffect } from "react";
 import InstructorView from "./views/InstructorView";
 import PresentationView from "./views/PresentationView";
 import StudentView from "./views/StudentView";
-import { fetchInstructorSessionStatus, loginInstructor } from "./hooks/api";
+import InstructorLoginPrompt from "./components/InstructorLoginPrompt";
+import { fetchInstructorSessionStatus } from "./hooks/api";
 
 const DEFAULT_INSTRUCTOR_ROUTE_SEGMENT = "instructor";
 
@@ -148,9 +149,7 @@ export default function App() {
 function InstructorGate({ returnTo, authContext }: { returnTo?: string; authContext?: AuthContext }) {
   const [checking, setChecking] = useState(true);
   const [authenticated, setAuthenticated] = useState(false);
-  const [password, setPassword] = useState("");
   const [error, setError] = useState<string | null>(null);
-  const [submitting, setSubmitting] = useState(false);
 
   useEffect(() => {
     fetchInstructorSessionStatus()
@@ -194,73 +193,26 @@ function InstructorGate({ returnTo, authContext }: { returnTo?: string; authCont
   const description = isPresentationLogin
     ? "Presentation mode is protected when the instructor password is enabled. Sign in and you will return to the presenter view."
     : "Enter the instructor password to access session controls.";
-  const submitLabel = submitting
-    ? "Signing in..."
-    : isPresentationLogin
-      ? "Sign In to Open Presentation"
-      : "Sign In";
-
-  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
-    event.preventDefault();
-    setSubmitting(true);
-    setError(null);
-    try {
-      await loginInstructor(password);
-      setPassword("");
-      if (returnTo) {
-        navigateToHashPath(returnTo);
-        return;
-      }
-      setAuthenticated(true);
-    } catch (e) {
-      setError(e instanceof Error ? e.message : "Login failed");
-    } finally {
-      setSubmitting(false);
-    }
-  }
 
   return (
     <div className="min-h-dvh flex flex-col items-center justify-center gap-8 p-6">
-      <div className="w-full max-w-md space-y-6">
-        <div className="text-center space-y-2">
-          <h1 className="text-3xl font-bold text-white">{title}</h1>
-          <p className="text-zinc-400">{description}</p>
-        </div>
-
-        <form onSubmit={handleSubmit} className="space-y-4">
-          <label htmlFor="instructor-password" className="block text-sm font-medium text-zinc-300">
-            Password
-          </label>
-          <input
-            id="instructor-password"
-            type="password"
-            value={password}
-            onChange={(event) => setPassword(event.target.value)}
-            className="w-full bg-zinc-900 border border-zinc-700 rounded-xl px-4 py-3 text-white focus:outline-none focus:ring-2 focus:ring-indigo-500"
-            autoComplete="current-password"
-            required
-          />
-
-          {error && <p className="text-sm text-red-300">{error}</p>}
-
-          <button
-            type="submit"
-            disabled={submitting || !password}
-            className="w-full bg-indigo-600 hover:bg-indigo-500 disabled:bg-zinc-700 disabled:text-zinc-500 text-white font-semibold py-3 rounded-xl transition-colors"
-          >
-            {submitLabel}
-          </button>
-        </form>
-
-        <div className="flex items-center justify-between text-sm">
-          <a href="#/" className="text-zinc-400 hover:text-zinc-200">
-            Back home
-          </a>
-          <a href={`#${INSTRUCTOR_HASH_ROUTE}`} className="text-zinc-400 hover:text-zinc-200">
-            Instructor controls
-          </a>
-        </div>
-      </div>
+      <InstructorLoginPrompt
+        title={title}
+        description={description}
+        submitLabel={isPresentationLogin ? "Sign In to Open Presentation" : "Sign In"}
+        onSuccess={() => {
+          if (returnTo) {
+            navigateToHashPath(returnTo);
+            return;
+          }
+          setAuthenticated(true);
+        }}
+        backHref="#/"
+        backLabel="Back home"
+        secondaryHref={`#${INSTRUCTOR_HASH_ROUTE}`}
+        secondaryLabel="Instructor controls"
+      />
+      {error && <p className="text-sm text-red-300">{error}</p>}
     </div>
   );
 }

--- a/packages/client/src/components/InstructorLoginPrompt.tsx
+++ b/packages/client/src/components/InstructorLoginPrompt.tsx
@@ -1,0 +1,98 @@
+import { useState, type FormEvent, type ReactNode } from "react";
+import { loginInstructor } from "../hooks/api";
+
+interface InstructorLoginPromptProps {
+  title: string;
+  description: ReactNode;
+  submitLabel: string;
+  submittingLabel?: string;
+  onSuccess: () => Promise<void> | void;
+  backHref?: string;
+  backLabel?: string;
+  secondaryHref?: string;
+  secondaryLabel?: string;
+}
+
+export default function InstructorLoginPrompt({
+  title,
+  description,
+  submitLabel,
+  submittingLabel = "Signing in...",
+  onSuccess,
+  backHref,
+  backLabel,
+  secondaryHref,
+  secondaryLabel,
+}: InstructorLoginPromptProps) {
+  const [password, setPassword] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+
+  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setSubmitting(true);
+    setError(null);
+
+    try {
+      await loginInstructor(password);
+      setPassword("");
+      await onSuccess();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Login failed");
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <div className="w-full max-w-md space-y-6">
+      <div className="text-center space-y-2">
+        <h1 className="text-3xl font-bold text-white">{title}</h1>
+        <p className="text-zinc-400">{description}</p>
+      </div>
+
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <label htmlFor="instructor-password" className="block text-sm font-medium text-zinc-300">
+          Password
+        </label>
+        <input
+          id="instructor-password"
+          type="password"
+          value={password}
+          onChange={(event) => setPassword(event.target.value)}
+          className="w-full bg-zinc-900 border border-zinc-700 rounded-xl px-4 py-3 text-white focus:outline-none focus:ring-2 focus:ring-indigo-500"
+          autoComplete="current-password"
+          required
+        />
+
+        {error && <p className="text-sm text-red-300">{error}</p>}
+
+        <button
+          type="submit"
+          disabled={submitting || !password}
+          className="w-full bg-indigo-600 hover:bg-indigo-500 disabled:bg-zinc-700 disabled:text-zinc-500 text-white font-semibold py-3 rounded-xl transition-colors"
+        >
+          {submitting ? submittingLabel : submitLabel}
+        </button>
+      </form>
+
+      {(backHref || secondaryHref) && (
+        <div className="flex items-center justify-between text-sm">
+          {backHref ? (
+            <a href={backHref} className="text-zinc-400 hover:text-zinc-200">
+              {backLabel || "Back"}
+            </a>
+          ) : (
+            <span />
+          )}
+
+          {secondaryHref ? (
+            <a href={secondaryHref} className="text-zinc-400 hover:text-zinc-200">
+              {secondaryLabel || "More"}
+            </a>
+          ) : null}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/client/src/hooks/api.ts
+++ b/packages/client/src/hooks/api.ts
@@ -208,7 +208,9 @@ export async function fetchSessionStateForRestore(sessionId: string): Promise<Se
 }
 
 export async function fetchPresentationSession(sessionId: string): Promise<PresentationSessionResponse> {
-  const res = await fetch(apiPath(API.SESSION_PRESENTATION, { id: sessionId }));
+  const res = await fetch(apiPath(API.SESSION_PRESENTATION, { id: sessionId }), {
+    credentials: "same-origin",
+  });
   if (!res.ok) {
     const data = await res.json().catch(() => ({}));
     throw new Error(data.error || "Failed to load presentation session");

--- a/packages/client/src/views/PresentationView.tsx
+++ b/packages/client/src/views/PresentationView.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useState } from "react";
 import type { SessionState } from "@mdq/shared";
+import InstructorLoginPrompt from "../components/InstructorLoginPrompt";
 import { fetchPresentationSession, type PresentationSessionResponse } from "../hooks/api";
 import { useSocket, type QuestionState, type RevealState } from "../hooks/useSocket";
 import Timer from "../components/Timer";
@@ -49,6 +50,22 @@ export default function PresentationView({ sessionId, loginHref }: { sessionId: 
     };
   }, [sessionId]);
 
+  async function retryPresentationFetch() {
+    setLoading(true);
+    setErrorMsg(null);
+
+    try {
+      const data = await fetchPresentationSession(sessionId);
+      setMeta(data);
+    } catch (error) {
+      setErrorMsg(error instanceof Error ? error.message : "Unable to load presentation session.");
+      setMeta(null);
+      throw error;
+    } finally {
+      setLoading(false);
+    }
+  }
+
   const state = (sock.sessionState || meta?.state || null) as SessionState | null;
   const quizLabel = formatQuizLabel(meta?.week || "");
   const accessInfo = meta?.accessInfo || null;
@@ -81,20 +98,24 @@ export default function PresentationView({ sessionId, loginHref }: { sessionId: 
   if (errorMsg || !meta || !state) {
     if (isInstructorLoginRequired(errorMsg)) {
       return (
-        <div className="min-h-dvh flex flex-col items-center justify-center gap-4 p-6 text-center">
-          <h1 className="text-3xl font-bold text-white">Instructor login required</h1>
-          <p className="max-w-lg text-zinc-400">
-            This presenter view is protected when instructor auth is enabled. Sign in and you will return straight to presentation mode.
-          </p>
-          <a
-            href={loginHref}
-            className="rounded-xl bg-indigo-600 px-6 py-3 font-semibold text-white transition-colors hover:bg-indigo-500"
-          >
-            Sign in to open presentation
-          </a>
-          <a href="#/" className="text-sm text-zinc-400 hover:text-zinc-200">
-            Back home
-          </a>
+        <div className="min-h-dvh flex flex-col items-center justify-center gap-8 p-6">
+          <div className="text-center space-y-3">
+            <p className="text-sm uppercase tracking-[0.22em] text-zinc-500">Presentation Mode</p>
+            <p className="max-w-xl text-zinc-400">
+              This presenter view is protected when instructor auth is enabled. Sign in here and presentation mode will continue automatically.
+            </p>
+          </div>
+
+          <InstructorLoginPrompt
+            title="Instructor login required"
+            description="Enter the instructor password to continue into presenter mode."
+            submitLabel="Sign In to Open Presentation"
+            onSuccess={retryPresentationFetch}
+            backHref="#/"
+            backLabel="Back home"
+            secondaryHref={loginHref}
+            secondaryLabel="Open full sign-in page"
+          />
         </div>
       );
     }

--- a/packages/client/src/views/PresentationView.tsx
+++ b/packages/client/src/views/PresentationView.tsx
@@ -9,6 +9,8 @@ import QRPanel from "../components/QRPanel";
 import QuizHtml from "../components/QuizHtml";
 import { getQuestionModeText } from "../questionMode";
 
+const EMPTY_QUESTION_HEADINGS: string[] = [];
+
 function formatQuizLabel(quizKey: string): string {
   const normalized = quizKey.trim();
   if (!normalized) return "MDQ";
@@ -16,11 +18,15 @@ function formatQuizLabel(quizKey: string): string {
   return `${normalized} MDQ`;
 }
 
-export default function PresentationView({ sessionId }: { sessionId: string }) {
+function isInstructorLoginRequired(message: string | null): boolean {
+  return (message || "").toLowerCase().includes("login required");
+}
+
+export default function PresentationView({ sessionId, loginHref }: { sessionId: string; loginHref: string }) {
   const [meta, setMeta] = useState<PresentationSessionResponse | null>(null);
   const [loading, setLoading] = useState(true);
   const [errorMsg, setErrorMsg] = useState<string | null>(null);
-  const sock = useSocket(sessionId, "presentation");
+  const sock = useSocket(meta ? sessionId : null, "presentation");
 
   useEffect(() => {
     let cancelled = false;
@@ -40,14 +46,13 @@ export default function PresentationView({ sessionId }: { sessionId: string }) {
 
     return () => {
       cancelled = true;
-      sock.disconnect();
     };
   }, [sessionId]);
 
   const state = (sock.sessionState || meta?.state || null) as SessionState | null;
   const quizLabel = formatQuizLabel(meta?.week || "");
   const accessInfo = meta?.accessInfo || null;
-  const questionHeadings = meta?.questionHeadings || [];
+  const questionHeadings = meta?.questionHeadings || EMPTY_QUESTION_HEADINGS;
   const totalQuestions = meta?.questionCount || 0;
   const currentQuestion = sock.currentQuestion as QuestionState | null;
   const reveal = sock.reveal as RevealState | null;
@@ -74,6 +79,26 @@ export default function PresentationView({ sessionId }: { sessionId: string }) {
   }
 
   if (errorMsg || !meta || !state) {
+    if (isInstructorLoginRequired(errorMsg)) {
+      return (
+        <div className="min-h-dvh flex flex-col items-center justify-center gap-4 p-6 text-center">
+          <h1 className="text-3xl font-bold text-white">Instructor login required</h1>
+          <p className="max-w-lg text-zinc-400">
+            This presenter view is protected when instructor auth is enabled. Sign in and you will return straight to presentation mode.
+          </p>
+          <a
+            href={loginHref}
+            className="rounded-xl bg-indigo-600 px-6 py-3 font-semibold text-white transition-colors hover:bg-indigo-500"
+          >
+            Sign in to open presentation
+          </a>
+          <a href="#/" className="text-sm text-zinc-400 hover:text-zinc-200">
+            Back home
+          </a>
+        </div>
+      );
+    }
+
     return (
       <div className="min-h-dvh flex flex-col items-center justify-center gap-4 p-6 text-center">
         <h1 className="text-3xl font-bold text-white">Presentation unavailable</h1>

--- a/packages/server/src/__tests__/lifecycle.test.ts
+++ b/packages/server/src/__tests__/lifecycle.test.ts
@@ -81,6 +81,36 @@ describe("REST API", () => {
       expect(status.body.authenticated).toBe(true);
       expect(status.body.configured).toBe(false);
     });
+
+    it("requires instructor auth for presentation metadata when password is configured", async () => {
+      process.env.INSTRUCTOR_PASSWORD = "presentation-secret";
+      const protectedApp = createApp(quizDir);
+
+      const agent = request.agent(protectedApp);
+      await agent
+        .post("/api/instructor/login")
+        .send({ password: "presentation-secret" })
+        .expect(204);
+
+      const createRes = await agent
+        .post("/api/session")
+        .send({ week: "week01" })
+        .expect(201);
+
+      await request(protectedApp)
+        .get(`/api/session/${createRes.body.sessionId}/presentation`)
+        .expect(401);
+
+      const res = await agent
+        .get(`/api/session/${createRes.body.sessionId}/presentation`)
+        .set("Host", "quiz-host.local:3001")
+        .expect(200);
+
+      expect(res.body.sessionId).toBe(createRes.body.sessionId);
+      expect(res.body.accessInfo.presentationUrl).toBe(
+        `http://quiz-host.local:3001/#/present/${createRes.body.sessionId}`,
+      );
+    });
   });
 
   describe("GET /api/health", () => {
@@ -539,7 +569,7 @@ Name the file to edit.
       expect(res.body.qrTargetUrl).toContain(`/join/${createRes.body.sessionCode}`);
     });
 
-    it("returns public presentation metadata for an active session", async () => {
+    it("returns presentation metadata for an active session when instructor auth is disabled", async () => {
       const createRes = await request(app)
         .post("/api/session")
         .send({ week: "week01" })

--- a/packages/server/src/__tests__/socket.test.ts
+++ b/packages/server/src/__tests__/socket.test.ts
@@ -975,50 +975,64 @@ describe("Socket.IO Integration", () => {
       student.disconnect();
     });
 
-    it("presentation view connects without instructor auth and receives live snapshot", async () => {
-      process.env.INSTRUCTOR_PASSWORD = "presentation-test-secret";
-      clearInstructorSessionsForTests();
-
-      const session = createSession("week01", "open");
-      storeSession(session);
-
-      const student = createClient(session.sessionId);
-      student.connect();
-      const joinedPromise = waitForEvent(student, SocketEvents.STUDENT_JOINED);
-      student.emit(SocketEvents.STUDENT_JOIN, { studentId: "S001" });
-      await joinedPromise;
-
-      transitionState(session, "QUESTION_OPEN");
-      session.currentQuestionIndex = 0;
-      session.questionStartedAt = Date.now() - 1000;
-
-      const presentation = createPresentationClient(session.sessionId);
-      const participantsPromise = waitForEvent<{ count: number }>(presentation, SocketEvents.SESSION_PARTICIPANTS);
-      const statePromise = waitForEvent<{ state: string; questionIndex?: number }>(presentation, SocketEvents.SESSION_STATE);
-      const openPromise = waitForEvent<{ questionIndex: number }>(presentation, SocketEvents.QUESTION_OPEN);
-      const countPromise = waitForEvent<{ questionIndex: number; submitted: number; total: number }>(presentation, SocketEvents.ANSWER_COUNT);
-
-      presentation.connect();
-
-      const [participants, state, open, count] = await Promise.all([
-        participantsPromise,
-        statePromise,
-        openPromise,
-        countPromise,
-      ]);
-
-      expect(participants.count).toBe(1);
-      expect(state.state).toBe("QUESTION_OPEN");
-      expect(state.questionIndex).toBe(0);
-      expect(open.questionIndex).toBe(0);
-      expect(count.submitted).toBe(0);
-      expect(count.total).toBe(1);
-
-      clearSessionTimers(session.sessionId);
-      presentation.disconnect();
-      student.disconnect();
+    it("presentation view connects without instructor auth when no password is configured", async () => {
+      const originalInstructorPassword = process.env.INSTRUCTOR_PASSWORD;
       delete process.env.INSTRUCTOR_PASSWORD;
       clearInstructorSessionsForTests();
+
+      try {
+        const session = createSession("week01", "open");
+        storeSession(session);
+
+        const student = createClient(session.sessionId);
+        student.connect();
+        const joinedPromise = waitForEvent(student, SocketEvents.STUDENT_JOINED);
+        student.emit(SocketEvents.STUDENT_JOIN, { studentId: "S001" });
+        await joinedPromise;
+
+        transitionState(session, "QUESTION_OPEN");
+        session.currentQuestionIndex = 0;
+        session.questionStartedAt = Date.now() - 1000;
+
+        const presentation = createPresentationClient(session.sessionId);
+        const participantsPromise = waitForEvent<{ count: number }>(presentation, SocketEvents.SESSION_PARTICIPANTS);
+        const statePromise = waitForEvent<{ state: string; questionIndex?: number }>(
+          presentation,
+          SocketEvents.SESSION_STATE,
+        );
+        const openPromise = waitForEvent<{ questionIndex: number }>(presentation, SocketEvents.QUESTION_OPEN);
+        const countPromise = waitForEvent<{ questionIndex: number; submitted: number; total: number }>(
+          presentation,
+          SocketEvents.ANSWER_COUNT,
+        );
+
+        presentation.connect();
+
+        const [participants, state, open, count] = await Promise.all([
+          participantsPromise,
+          statePromise,
+          openPromise,
+          countPromise,
+        ]);
+
+        expect(participants.count).toBe(1);
+        expect(state.state).toBe("QUESTION_OPEN");
+        expect(state.questionIndex).toBe(0);
+        expect(open.questionIndex).toBe(0);
+        expect(count.submitted).toBe(0);
+        expect(count.total).toBe(1);
+
+        clearSessionTimers(session.sessionId);
+        presentation.disconnect();
+        student.disconnect();
+      } finally {
+        if (typeof originalInstructorPassword === "string") {
+          process.env.INSTRUCTOR_PASSWORD = originalInstructorPassword;
+        } else {
+          delete process.env.INSTRUCTOR_PASSWORD;
+        }
+        clearInstructorSessionsForTests();
+      }
     });
 
     it("late join during open_response QUESTION_OPEN rebroadcasts live answer count before submission", async () => {
@@ -1435,6 +1449,66 @@ describe("Socket.IO Integration", () => {
         });
 
         authInstructor.disconnect();
+      } finally {
+        authIo.close();
+        await new Promise<void>((resolve) => authServer.close(() => resolve()));
+      }
+    });
+
+    it("rejects unauthenticated presentation socket when password is configured", async () => {
+      process.env.INSTRUCTOR_PASSWORD = "presentation-test-secret";
+
+      const authApp = createApp(quizDir);
+      const authServer = createServer(authApp);
+      const authQuizzes = (authApp as unknown as { _quizzes: Map<string, Quiz> })._quizzes;
+      const authIo = setupSocket(authServer, authQuizzes);
+
+      await new Promise<void>((resolve) => authServer.listen(0, resolve));
+      try {
+        const authPort = (authServer.address() as AddressInfo).port;
+        const authBaseUrl = `http://localhost:${authPort}`;
+
+        const createRes = await request(authApp)
+          .post("/api/instructor/login")
+          .send({ password: "presentation-test-secret" })
+          .expect(204);
+        const cookieHeader = createRes.headers["set-cookie"][0].split(";")[0];
+
+        const sessionRes = await request(authApp)
+          .post("/api/session")
+          .set("Cookie", cookieHeader)
+          .send({ week: "week01" })
+          .expect(201);
+
+        const unauthPresentation = ioClient(authBaseUrl, {
+          autoConnect: false,
+          auth: { sessionId: sessionRes.body.sessionId, role: "presentation" },
+          transports: ["websocket"],
+        });
+
+        const rejectedPromise = waitForEvent<{ reason: string }>(
+          unauthPresentation,
+          SocketEvents.STUDENT_REJECTED,
+        );
+
+        unauthPresentation.connect();
+        const rejected = await rejectedPromise;
+        expect(rejected.reason).toContain("login required");
+        unauthPresentation.disconnect();
+
+        const authPresentation = ioClient(authBaseUrl, {
+          autoConnect: false,
+          auth: { sessionId: sessionRes.body.sessionId, role: "presentation" },
+          transports: ["websocket"],
+          extraHeaders: { Cookie: cookieHeader },
+        });
+
+        await new Promise<void>((resolve) => {
+          authPresentation.once("connect", () => resolve());
+          authPresentation.connect();
+        });
+
+        authPresentation.disconnect();
       } finally {
         authIo.close();
         await new Promise<void>((resolve) => authServer.close(() => resolve()));

--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -690,7 +690,7 @@ export function createApp(quizDirOrOpts?: string | AppOptions) {
     return res.json(await buildSessionAccessInfo(fallbackBase, session.sessionId, session.sessionCode));
   });
 
-  app.get(API.SESSION_PRESENTATION, async (req, res) => {
+  app.get(API.SESSION_PRESENTATION, requireInstructorAuth, async (req, res) => {
     const session = getSession(req.params.id);
     if (!session) {
       return res.status(404).json({ error: "Session not found" });

--- a/packages/server/src/socket.ts
+++ b/packages/server/src/socket.ts
@@ -289,9 +289,9 @@ export function setupSocket(httpServer: HttpServer, quizzes: Map<string, Quiz>):
       const isInstructor = role === "instructor";
       if (isInstructorAuthEnabled()) {
         const sessionToken = getInstructorSessionFromCookie(socket.handshake.headers.cookie);
-        if (isInstructor && (!sessionToken || !hasValidInstructorSession(sessionToken))) {
+        if (!sessionToken || !hasValidInstructorSession(sessionToken)) {
           socket.emit(SocketEvents.STUDENT_REJECTED, { reason: "Instructor login required" });
-          logActivity(`reject instructor socket=${socket.id} session=${sessionId} reason=unauthenticated`);
+          logActivity(`reject ${isInstructor ? "instructor" : "presentation"} socket=${socket.id} session=${sessionId} reason=unauthenticated`);
           socket.disconnect();
           return;
         }


### PR DESCRIPTION
## Summary
- require instructor auth for the presentation metadata endpoint when `INSTRUCTOR_PASSWORD` is enabled
- require instructor auth for presentation sockets under the same condition
- preserve existing presentation access behavior when instructor auth is disabled
- add targeted REST and socket coverage for the protected and unprotected cases

Fixes #18

## Validation
- `npx jest --runInBand --forceExit --detectOpenHandles --config packages/server/jest.config.js --runTestsByPath packages/server/src/__tests__/lifecycle.test.ts packages/server/src/__tests__/socket.test.ts`
- targeted result: 69 tests passed
