### PR TITLE
Fix slide spacing and bump beta version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mdq",
-  "version": "0.3.1-beta",
+  "version": "0.3.3-beta",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mdq",
-      "version": "0.3.1-beta",
+      "version": "0.3.3-beta",
       "workspaces": [
         "packages/*"
       ],
@@ -9274,7 +9274,7 @@
     },
     "packages/client": {
       "name": "@mdq/client",
-      "version": "0.3.1-beta",
+      "version": "0.3.3-beta",
       "dependencies": {
         "@mdq/shared": "*",
         "react": "^19.2.0",
@@ -9539,7 +9539,7 @@
     },
     "packages/server": {
       "name": "@mdq/server",
-      "version": "0.3.1-beta",
+      "version": "0.3.3-beta",
       "dependencies": {
         "@mdq/shared": "*",
         "cors": "^2.8.5",
@@ -9565,7 +9565,7 @@
     },
     "packages/shared": {
       "name": "@mdq/shared",
-      "version": "0.3.1-beta"
+      "version": "0.3.3-beta"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mdq",
-  "version": "0.3.1-beta",
+  "version": "0.3.3-beta",
   "private": true,
   "workspaces": [
     "packages/*"

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mdq/client",
   "private": true,
-  "version": "0.3.1-beta",
+  "version": "0.3.3-beta",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/packages/client/src/App.tsx
+++ b/packages/client/src/App.tsx
@@ -162,6 +162,24 @@ export default function App({ runtimeConfig = {} }: { runtimeConfig?: RuntimeCli
           <span className="text-zinc-300">No clunky interfaces. No proprietary nonsense. No database.</span>
           <br />
           <span className="text-zinc-400">Just your own machine and a public secure tunnel (like Tailscale).</span>
+          <br />
+          <a
+            href="https://github.com/chektien/mdq"
+            target="_blank"
+            rel="noreferrer"
+            className="inline-flex items-center justify-center gap-1.5 text-zinc-300 transition-colors hover:text-white"
+          >
+            Open-source
+            <svg
+              aria-label="GitHub"
+              className="h-5 w-5"
+              viewBox="0 0 24 24"
+              role="img"
+              fill="currentColor"
+            >
+              <path d="M12 2C6.48 2 2 6.58 2 12.25c0 4.52 2.87 8.35 6.84 9.71.5.09.68-.22.68-.49 0-.24-.01-.88-.01-1.73-2.78.62-3.37-1.37-3.37-1.37-.45-1.19-1.11-1.51-1.11-1.51-.91-.64.07-.63.07-.63 1 .07 1.53 1.06 1.53 1.06.89 1.57 2.34 1.12 2.91.86.09-.66.35-1.12.63-1.38-2.22-.26-4.55-1.14-4.55-5.07 0-1.12.39-2.03 1.03-2.75-.1-.26-.45-1.31.1-2.72 0 0 .84-.28 2.75 1.05A9.37 9.37 0 0 1 12 6.94c.85 0 1.7.12 2.5.34 1.91-1.33 2.75-1.05 2.75-1.05.55 1.41.2 2.46.1 2.72.64.72 1.03 1.63 1.03 2.75 0 3.94-2.34 4.8-4.57 5.06.36.32.68.94.68 1.9 0 1.37-.01 2.47-.01 2.81 0 .27.18.59.69.49A10.08 10.08 0 0 0 22 12.25C22 6.58 17.52 2 12 2Z" />
+            </svg>
+          </a>
         </p>
       </div>
       <div className="flex w-full max-w-sm flex-col gap-4 sm:flex-row">

--- a/packages/client/src/index.css
+++ b/packages/client/src/index.css
@@ -998,7 +998,11 @@ html[data-theme="light"] .slide-surface::after {
 }
 
 .slide-content-grid-text-only {
-  max-width: min(62cqi, 70rem);
+  max-width: min(82cqi, 92rem);
+}
+
+.slide-content-grid-text-only .slide-body {
+  max-width: 100%;
 }
 
 .slide-content-grid-with-media {
@@ -2225,6 +2229,15 @@ html[data-theme="light"] .slide-surface::after {
 .quiz-html p { margin: 0.5em 0; }
 .slide-body.quiz-html p {
   margin: 0 0 1.3cqi;
+}
+
+.slide-body.quiz-html ul + p,
+.slide-body.quiz-html ol + p,
+.slide-body.quiz-html ul + h3,
+.slide-body.quiz-html ol + h3,
+.slide-body.quiz-html ul + h4,
+.slide-body.quiz-html ol + h4 {
+  margin-top: clamp(0.8rem, 1.45cqi, 1.55rem);
 }
 
 .slide-body.quiz-html li > p,

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdq/server",
-  "version": "0.3.1-beta",
+  "version": "0.3.3-beta",
   "private": true,
   "main": "dist/index.js",
   "scripts": {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdq/shared",
-  "version": "0.3.1-beta",
+  "version": "0.3.3-beta",
   "private": true,
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Summary
- widens text-only slide content and avoids nested body width caps
- adds spacing after lists before following paragraphs/headings
- bumps MDQ beta package versions to 0.4.0-beta

## Validation
- `npm run typecheck`

Closes #30
