### PR TITLE
Add guarded one-command try flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,46 @@ Use MDQ when you want:
 The repository intentionally keeps `data/` local-first. Only public sample data
 should be committed.
 
-## First-Time Setup
+## Try MDQ Now
+
+From a fresh checkout, run:
+
+```bash
+npm run try
+```
+
+This one command installs dependencies, creates local runtime folders, copies the
+public sample deck, builds the app, checks the available network mode, and starts
+the MDQ server. The launcher defaults to port `2081`; override it with `PORT`:
+
+```bash
+PORT=3000 npm run try
+```
+
+The launcher prints the requested instructor URL before the server starts, and
+the server prints the actual bound URL if it has to use a fallback port. If
+Tailscale is unavailable, it clearly marks the run as local/mock testing only:
+good for checking how the quiz looks, projector flow, and mock students, but not
+a real public classroom link. After creating a session, you can simulate students
+locally with the mock-student command printed by the launcher.
+
+If Tailscale is available, the launcher binds MDQ to localhost so it can sit
+behind a proxy without competing with Tailscale's own listener. It checks whether
+Funnel already proxies to the MDQ port, but it will not rewrite the shared
+Tailscale hostname automatically because that hostname may already serve other
+tools. To see the guarded publish path, run:
+
+```bash
+npm run try -- --publish
+```
+
+For a strictly local run that never offers to change Tailscale Funnel state:
+
+```bash
+npm run try -- --local-only
+```
+
+## Manual First-Time Setup
 
 Install dependencies and create local runtime folders:
 
@@ -93,7 +132,7 @@ npm run start --workspace=@mdq/server
 Open the instructor route locally:
 
 ```text
-http://localhost:3000/#/instructor
+http://localhost:2081/#/instructor
 ```
 
 For class use, set `INSTRUCTOR_PASSWORD` and expose only the student join URL or

--- a/package.json
+++ b/package.json
@@ -7,6 +7,9 @@
   ],
   "scripts": {
     "setup:local": "bash ./scripts/setup-local.sh",
+    "try": "bash ./scripts/try-mdq.sh",
+    "try:local": "bash ./scripts/try-mdq.sh --local-only",
+    "try:publish": "bash ./scripts/try-mdq.sh --publish",
     "build": "npm run build --workspace=@mdq/shared && npm run build --workspace=@mdq/server && npm run build --workspace=@mdq/client",
     "test": "npm run build --workspace=@mdq/shared && npm run test --workspace=@mdq/server",
     "lint": "eslint packages/*/src --ext .ts,.tsx",

--- a/packages/server/src/__tests__/access-info.test.ts
+++ b/packages/server/src/__tests__/access-info.test.ts
@@ -23,6 +23,7 @@ beforeEach(() => {
   mockExecSync.mockReset();
   setCachedAccessInfo(null);
   delete process.env.MDQ_PUBLIC_URL;
+  delete process.env.MDQ_DISABLE_TAILSCALE;
 });
 
 describe("detectTailscaleUrl", () => {
@@ -60,6 +61,16 @@ describe("detectTailscaleUrl", () => {
       throw new Error("command not found: tailscale");
     });
     expect(detectTailscaleUrl()).toBeNull();
+  });
+
+  it("returns null when tailscale detection is disabled", () => {
+    process.env.MDQ_DISABLE_TAILSCALE = "1";
+    mockExecSync.mockReturnValue(
+      JSON.stringify({ Self: { DNSName: "quiz-host.tailnet.ts.net." } }),
+    );
+
+    expect(detectTailscaleUrl()).toBeNull();
+    expect(mockExecSync).not.toHaveBeenCalled();
   });
 
   it("returns null when tailscale times out", () => {
@@ -272,6 +283,18 @@ describe("detectAccessInfo", () => {
     expect(info.qrTargetUrl).toBe(info.fullUrl);
     expect(info.warning).toBeDefined();
     expect(info.warning).toContain("Tailscale unavailable");
+  });
+
+  it("falls back to LAN when tailscale detection is disabled", async () => {
+    process.env.MDQ_DISABLE_TAILSCALE = "true";
+    mockExecSync.mockReturnValue(
+      JSON.stringify({ Self: { DNSName: "quiz-host.tailnet.ts.net." } }),
+    );
+
+    const info = await detectAccessInfo(2081, []);
+    expect(info.source).toBe("lan-fallback");
+    expect(info.fullUrl).toMatch(/^http:\/\/\d+\.\d+\.\d+\.\d+:2081$/);
+    expect(info.warning).toContain("Local/mock mode");
   });
 
   it("caches access info after detection", async () => {

--- a/packages/server/src/__tests__/config.test.ts
+++ b/packages/server/src/__tests__/config.test.ts
@@ -17,6 +17,7 @@ describe("loadRuntimeConfig", () => {
 
     expect(config.loadedFromFile).toBe(false);
     expect(config.port).toBe(DEFAULT_PORT);
+    expect(config.bindHost).toBe("");
     expect(config.portFallbacks).toBe(10);
     expect(config.quizDir).toBe(path.join(root, "data", "decks"));
     expect(config.instanceId).toBe("");
@@ -30,6 +31,7 @@ describe("loadRuntimeConfig", () => {
       path.join(root, "data", "config.json"),
       JSON.stringify({
         port: 3100,
+        bindHost: "127.0.0.1",
         portFallbacks: 4,
         deckDir: "./alt-decks",
         instanceId: "room-a",
@@ -42,6 +44,7 @@ describe("loadRuntimeConfig", () => {
 
     expect(config.loadedFromFile).toBe(true);
     expect(config.port).toBe(3100);
+    expect(config.bindHost).toBe("127.0.0.1");
     expect(config.portFallbacks).toBe(4);
     expect(config.quizDir).toBe(path.join(root, "data", "alt-decks"));
     expect(config.instanceId).toBe("room-a");
@@ -60,6 +63,7 @@ describe("loadRuntimeConfig", () => {
       rootDir: root,
       env: {
         PORT: "3200",
+        MDQ_BIND_HOST: "localhost",
         PORT_FALLBACKS: "1",
         MDQ_DECK_DIR: path.join(root, "custom-decks"),
         MDQ_INSTANCE_ID: "room-b",
@@ -69,6 +73,7 @@ describe("loadRuntimeConfig", () => {
     });
 
     expect(config.port).toBe(3200);
+    expect(config.bindHost).toBe("localhost");
     expect(config.portFallbacks).toBe(1);
     expect(config.quizDir).toBe(path.join(root, "custom-decks"));
     expect(config.instanceId).toBe("room-b");

--- a/packages/server/src/access-info.ts
+++ b/packages/server/src/access-info.ts
@@ -12,11 +12,20 @@ interface TailscaleStatus {
   };
 }
 
+function isTailscaleDetectionDisabled(): boolean {
+  const value = (process.env.MDQ_DISABLE_TAILSCALE || "").trim().toLowerCase();
+  return ["1", "true", "yes", "on"].includes(value);
+}
+
 /**
  * Detect the Tailscale Funnel URL by calling `tailscale status --json`.
  * Returns the DNS name (e.g., "my-laptop.tailnet.ts.net") or null if unavailable.
  */
 export function detectTailscaleUrl(): string | null {
+  if (isTailscaleDetectionDisabled()) {
+    return null;
+  }
+
   const configuredUrl = (process.env.MDQ_PUBLIC_URL || process.env.PUBLIC_URL || "").trim();
   if (configuredUrl) {
     return configuredUrl.replace(/\/+$/, "");
@@ -187,7 +196,9 @@ export async function detectAccessInfo(
     const lanIp = getLanIp();
     fullUrl = `http://${lanIp}:${port}`;
     source = "lan-fallback";
-    warning = "Tailscale unavailable. Students on isolated campus WiFi may not be able to connect.";
+    warning = isTailscaleDetectionDisabled()
+      ? "Local/mock mode: Tailscale detection is disabled for this run."
+      : "Tailscale unavailable. Students on isolated campus WiFi may not be able to connect.";
   }
 
   // Generate short URL

--- a/packages/server/src/config.ts
+++ b/packages/server/src/config.ts
@@ -6,6 +6,8 @@ const DEFAULT_PORT_FALLBACKS = 10;
 
 interface RuntimeConfigFile {
   port?: unknown;
+  host?: unknown;
+  bindHost?: unknown;
   portFallbacks?: unknown;
   deckDir?: unknown;
   quizDir?: unknown;
@@ -18,6 +20,7 @@ export type RuntimeTheme = "dark" | "light";
 
 export interface RuntimeConfig {
   port: number;
+  bindHost: string;
   portFallbacks: number;
   quizDir: string;
   instanceId: string;
@@ -138,6 +141,12 @@ export function loadRuntimeConfig(options: RuntimeConfigLoadOptions = {}): Runti
 
   return {
     port: parsePositiveInt(env.PORT) ?? parsePositiveInt(fileConfig.port) ?? DEFAULT_PORT,
+    bindHost:
+      parseString(env.MDQ_BIND_HOST)
+      ?? parseString(env.HOST)
+      ?? parseString(fileConfig.bindHost)
+      ?? parseString(fileConfig.host)
+      ?? "",
     portFallbacks:
       parseNonNegativeInt(env.PORT_FALLBACKS)
       ?? parseNonNegativeInt(fileConfig.portFallbacks)

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -21,11 +21,15 @@ import { isInstructorAuthEnabled } from "./instructor-auth";
 
 const runtimeConfig = loadRuntimeConfig();
 const requestedPort = runtimeConfig.port || DEFAULT_PORT;
+const bindHost = runtimeConfig.bindHost || undefined;
 const maxPortFallbacks = runtimeConfig.portFallbacks;
 const instanceId = runtimeConfig.instanceId || randomUUID();
 const dataDir = path.resolve(__dirname, "../../../data");
 const quizDir = runtimeConfig.quizDir || path.resolve(__dirname, "../../../data/decks");
 const clientDist = path.join(__dirname, "../../client/dist");
+const tailscaleDisabled = ["1", "true", "yes", "on"].includes(
+  (process.env.MDQ_DISABLE_TAILSCALE || "").trim().toLowerCase(),
+);
 
 // We need io available for the state change callback, so we use a container
 // that's populated after setupSocket. The callback won't fire before the server starts.
@@ -95,6 +99,25 @@ function inspectFunnelReadiness(publicUrl: string, boundPort: number): FunnelRea
         "run: tailscale funnel status",
       ],
     };
+  }
+}
+
+function logReadinessResult(params: {
+  title: string;
+  status: string;
+  url: string;
+  details?: string[];
+  nextSteps?: string[];
+}): void {
+  console.log("");
+  console.log(`mdq readiness result: ${params.title}`);
+  console.log(`  Status: ${params.status}`);
+  console.log(`  URL: ${params.url}`);
+  for (const detail of params.details || []) {
+    console.log(`  Detail: ${detail}`);
+  }
+  for (const nextStep of params.nextSteps || []) {
+    console.log(`  Next: ${nextStep}`);
   }
 }
 
@@ -188,6 +211,9 @@ async function onListening(): Promise<void> {
   const usedFallbackPort = boundPort !== requestedPort;
 
   console.log(`mdq server listening on port ${boundPort} (instance ${instanceId})`);
+  if (bindHost) {
+    console.log(`Bind host: ${bindHost}`);
+  }
   console.log(
     `Runtime config: ${runtimeConfig.loadedFromFile ? runtimeConfig.configPath : "defaults only (data/config.json not found)"}`,
   );
@@ -202,6 +228,7 @@ async function onListening(): Promise<void> {
   // Detect access info (Tailscale/LAN) on startup
   try {
     const info = await detectAccessInfo(boundPort);
+    let tailscaleHealthVerified = false;
     console.log(`Access URL: ${info.fullUrl} (source: ${info.source})`);
     if (info.shortUrl) {
       console.log(`Short URL: ${info.shortUrl}`);
@@ -211,25 +238,47 @@ async function onListening(): Promise<void> {
     }
 
     if (info.source === "public-override") {
-      console.log(
-        `[mdq readiness] public_url_override=true bound_port=${boundPort} public_url=${info.fullUrl}`,
-      );
+      logReadinessResult({
+        title: "using the configured public URL",
+        status: "MDQ will use the URL you configured.",
+        url: info.fullUrl,
+        details: [`Local server port: ${boundPort}`],
+      });
     } else if (info.source === "tailscale") {
       const readiness = inspectFunnelReadiness(info.fullUrl, boundPort);
-      console.log(
-        `[mdq readiness] funnel_ready=${readiness.ready} reason=${readiness.reason} bound_port=${boundPort} public_url=${info.fullUrl}`,
-      );
       if (!readiness.ready) {
-        for (const detail of readiness.details) {
-          console.warn(`[mdq readiness] ${detail}`);
-        }
+        logReadinessResult({
+          title: "Tailscale is available, but Funnel needs attention",
+          status: "The server is running, but the public classroom URL may not reach this MDQ instance yet.",
+          url: info.fullUrl,
+          details: [`Local server port: ${boundPort}`, `Check result: ${readiness.reason}`],
+          nextSteps: readiness.details,
+        });
       }
     } else {
-      console.log(
-        `[mdq readiness] funnel_ready=false reason=tailscale-unavailable bound_port=${boundPort} public_url=${info.fullUrl}`,
-      );
-      console.warn("[mdq readiness] public classroom access may fail without Tailscale Funnel");
-      console.warn(`[mdq readiness] run: tailscale funnel ${boundPort}`);
+      if (tailscaleDisabled) {
+        logReadinessResult({
+          title: "local test mode",
+          status: "MDQ is running locally. Tailscale checks are off for this run.",
+          url: info.fullUrl,
+          details: [
+            `Local server port: ${boundPort}`,
+            "Good for checking the UI, projector flow, and mock students on this machine.",
+          ],
+          nextSteps: ["Use npm run try -- --publish when you want to test a public classroom link."],
+        });
+      } else {
+        logReadinessResult({
+          title: "Tailscale Funnel is not available",
+          status: "MDQ is running on your local network, but this is probably not a reliable public classroom link.",
+          url: info.fullUrl,
+          details: [`Local server port: ${boundPort}`],
+          nextSteps: [
+            "Sign in to Tailscale or check that Tailscale is running.",
+            `To publish this port later, run: tailscale funnel ${boundPort}`,
+          ],
+        });
+      }
     }
 
     if (info.source === "tailscale") {
@@ -245,32 +294,51 @@ async function onListening(): Promise<void> {
           typeof payload.instanceId === "string" ? payload.instanceId : "";
 
         if (!response.ok || !publicInstanceId) {
-          console.warn(
-            `[mdq readiness] funnel_ready=false reason=health-mismatch bound_port=${boundPort} public_url=${info.fullUrl}`,
-          );
-          console.warn(`[mdq readiness] failed health probe at ${healthUrl}`);
-          console.warn("[mdq readiness] run: tailscale funnel status");
+          logReadinessResult({
+            title: "Tailscale URL did not pass the health check",
+            status: "The public URL responded unexpectedly, so students may not reach this MDQ instance.",
+            url: info.fullUrl,
+            details: [`Health check URL: ${healthUrl}`],
+            nextSteps: ["Run: tailscale funnel status"],
+          });
         } else if (publicInstanceId !== instanceId) {
-          console.warn(
-            `[mdq readiness] funnel_ready=false reason=instance-mismatch bound_port=${boundPort} public_url=${info.fullUrl}`,
-          );
-          console.warn(
-            `[mdq readiness] public host points to instance ${publicInstanceId}, local instance is ${instanceId}`,
-          );
-          console.warn("[mdq readiness] stop old process on published port and retry");
+          logReadinessResult({
+            title: "Tailscale URL points to another MDQ server",
+            status: "The public URL is not connected to this server process.",
+            url: info.fullUrl,
+            details: [
+              `Public instance: ${publicInstanceId}`,
+              `This instance: ${instanceId}`,
+            ],
+            nextSteps: ["Stop the old process on the published port, then restart MDQ."],
+          });
+        } else {
+          tailscaleHealthVerified = true;
+          logReadinessResult({
+            title: "Tailscale Funnel is ready",
+            status: "The public URL reaches this MDQ server.",
+            url: info.fullUrl,
+            details: [`Local server port: ${boundPort}`],
+          });
         }
       } catch (error) {
         const message = error instanceof Error ? error.message : "unknown";
-        console.warn(
-          `[mdq readiness] funnel_ready=false reason=health-unreachable bound_port=${boundPort} public_url=${info.fullUrl}`,
-        );
-        console.warn(`[mdq readiness] public health probe failed: ${message}`);
+        logReadinessResult({
+          title: "Tailscale URL could not be checked",
+          status: "The server is running, but MDQ could not confirm the public classroom URL.",
+          url: info.fullUrl,
+          details: [`Health check failed: ${message}`],
+          nextSteps: ["Check your network, then run: tailscale funnel status"],
+        });
       }
     }
 
     if (usedFallbackPort && info.source === "tailscale") {
       const healthUrl = `${info.fullUrl}/api/health`;
-      try {
+      if (tailscaleHealthVerified) {
+        console.log(`Verified public host routes to this instance (${instanceId}) after fallback.`);
+      } else {
+        try {
         const response = await fetch(healthUrl, { signal: AbortSignal.timeout(5000) });
         const payloadUnknown = await response.json().catch(() => ({}));
         const payload =
@@ -281,10 +349,20 @@ async function onListening(): Promise<void> {
           typeof payload.instanceId === "string" ? payload.instanceId : "";
 
         if (!response.ok || !publicInstanceId) {
-          console.error(
-            `Unsafe fallback detected: unable to verify public host ${healthUrl} for instance consistency while running on fallback port ${boundPort}.`
-          );
-          console.error("Refusing to continue to avoid split-brain sessions. Free the requested port and restart.");
+          logReadinessResult({
+            title: "stopped to avoid opening the wrong classroom link",
+            status: "MDQ had to move to a fallback port, but the public URL did not prove that it reaches this server.",
+            url: info.fullUrl,
+            details: [
+              `Requested port: ${requestedPort}`,
+              `Actual server port: ${boundPort}`,
+              `Health check URL: ${healthUrl}`,
+            ],
+            nextSteps: [
+              `Stop the process using port ${requestedPort}, then run npm run try again.`,
+              "For local testing only, run: npm run try -- --local-only",
+            ],
+          });
           httpServer.close(() => {
             process.exit(1);
           });
@@ -292,10 +370,21 @@ async function onListening(): Promise<void> {
         }
 
         if (publicInstanceId !== instanceId) {
-          console.error(
-            `Unsafe fallback detected: public host ${info.fullUrl} resolves to instance ${publicInstanceId}, but this process is instance ${instanceId} on port ${boundPort}.`
-          );
-          console.error("Refusing to continue to avoid split-brain sessions. Stop the old process on the public port and restart.");
+          logReadinessResult({
+            title: "stopped because the public URL points to another MDQ server",
+            status: "The fallback server started, but the classroom URL is connected to a different running MDQ instance.",
+            url: info.fullUrl,
+            details: [
+              `Requested port: ${requestedPort}`,
+              `Actual server port: ${boundPort}`,
+              `Public instance: ${publicInstanceId}`,
+              `This instance: ${instanceId}`,
+            ],
+            nextSteps: [
+              "Stop the old MDQ server on the published port, then run npm run try again.",
+              "For local testing only, run: npm run try -- --local-only",
+            ],
+          });
           httpServer.close(() => {
             process.exit(1);
           });
@@ -303,18 +392,27 @@ async function onListening(): Promise<void> {
         }
 
         console.log(`Verified public host routes to this instance (${instanceId}) after fallback.`);
-      } catch (error) {
-        console.error(
-          `Unsafe fallback detected: failed to verify public host ${healthUrl} while running on fallback port ${boundPort}.`
-        );
-        console.error("Refusing to continue to avoid split-brain sessions. Free the requested port and restart.");
-        if (error instanceof Error) {
-          console.error(`Verification error: ${error.message}`);
-        }
+        } catch (error) {
+          const message = error instanceof Error ? error.message : "unknown";
+          logReadinessResult({
+            title: "stopped because the public URL could not be checked",
+            status: "MDQ had to move to a fallback port, and it could not confirm that the public URL reaches this server.",
+            url: info.fullUrl,
+            details: [
+              `Requested port: ${requestedPort}`,
+              `Actual server port: ${boundPort}`,
+              `Health check failed: ${message}`,
+            ],
+            nextSteps: [
+              `Stop the process using port ${requestedPort}, then run npm run try again.`,
+              "For local testing only, run: npm run try -- --local-only",
+            ],
+          });
         httpServer.close(() => {
           process.exit(1);
         });
         return;
+        }
       }
     }
   } catch (e) {
@@ -346,7 +444,11 @@ function startWithPortFallback(portToTry: number, fallbackCount: number): void {
 
   httpServer.once("listening", handleListening);
   httpServer.once("error", handleError);
-  httpServer.listen(portToTry);
+  if (bindHost) {
+    httpServer.listen(portToTry, bindHost);
+  } else {
+    httpServer.listen(portToTry);
+  }
 }
 
 startWithPortFallback(requestedPort, 0);

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -41,6 +41,12 @@ interface FunnelReadinessResult {
   details: string[];
 }
 
+interface PublicHealthCheckResult {
+  ok: boolean;
+  instanceId: string;
+  error: string;
+}
+
 function inspectFunnelReadiness(publicUrl: string, boundPort: number): FunnelReadinessResult {
   try {
     const raw = execSync("tailscale funnel status --json", {
@@ -118,6 +124,39 @@ function logReadinessResult(params: {
   }
   for (const nextStep of params.nextSteps || []) {
     console.log(`  Next: ${nextStep}`);
+  }
+}
+
+async function checkPublicHealth(publicUrl: string): Promise<PublicHealthCheckResult> {
+  const healthUrl = `${publicUrl}/api/health`;
+  try {
+    const response = await fetch(healthUrl, { signal: AbortSignal.timeout(5000) });
+    const payloadUnknown = await response.json().catch(() => ({}));
+    const payload =
+      payloadUnknown && typeof payloadUnknown === "object"
+        ? (payloadUnknown as { instanceId?: unknown })
+        : {};
+    const publicInstanceId = typeof payload.instanceId === "string" ? payload.instanceId : "";
+
+    if (!response.ok || !publicInstanceId) {
+      return {
+        ok: false,
+        instanceId: publicInstanceId,
+        error: `unexpected health response from ${healthUrl}`,
+      };
+    }
+
+    return {
+      ok: true,
+      instanceId: publicInstanceId,
+      error: "",
+    };
+  } catch (error) {
+    return {
+      ok: false,
+      instanceId: "",
+      error: error instanceof Error ? error.message : "unknown",
+    };
   }
 }
 
@@ -283,52 +322,34 @@ async function onListening(): Promise<void> {
 
     if (info.source === "tailscale") {
       const healthUrl = `${info.fullUrl}/api/health`;
-      try {
-        const response = await fetch(healthUrl, { signal: AbortSignal.timeout(5000) });
-        const payloadUnknown = await response.json().catch(() => ({}));
-        const payload =
-          payloadUnknown && typeof payloadUnknown === "object"
-            ? (payloadUnknown as { instanceId?: unknown })
-            : {};
-        const publicInstanceId =
-          typeof payload.instanceId === "string" ? payload.instanceId : "";
+      const health = await checkPublicHealth(info.fullUrl);
 
-        if (!response.ok || !publicInstanceId) {
-          logReadinessResult({
-            title: "Tailscale URL did not pass the health check",
-            status: "The public URL responded unexpectedly, so students may not reach this MDQ instance.",
-            url: info.fullUrl,
-            details: [`Health check URL: ${healthUrl}`],
-            nextSteps: ["Run: tailscale funnel status"],
-          });
-        } else if (publicInstanceId !== instanceId) {
-          logReadinessResult({
-            title: "Tailscale URL points to another MDQ server",
-            status: "The public URL is not connected to this server process.",
-            url: info.fullUrl,
-            details: [
-              `Public instance: ${publicInstanceId}`,
-              `This instance: ${instanceId}`,
-            ],
-            nextSteps: ["Stop the old process on the published port, then restart MDQ."],
-          });
-        } else {
-          tailscaleHealthVerified = true;
-          logReadinessResult({
-            title: "Tailscale Funnel is ready",
-            status: "The public URL reaches this MDQ server.",
-            url: info.fullUrl,
-            details: [`Local server port: ${boundPort}`],
-          });
-        }
-      } catch (error) {
-        const message = error instanceof Error ? error.message : "unknown";
+      if (!health.ok) {
         logReadinessResult({
           title: "Tailscale URL could not be checked",
           status: "The server is running, but MDQ could not confirm the public classroom URL.",
           url: info.fullUrl,
-          details: [`Health check failed: ${message}`],
+          details: [`Health check URL: ${healthUrl}`, `Health check failed: ${health.error}`],
           nextSteps: ["Check your network, then run: tailscale funnel status"],
+        });
+      } else if (health.instanceId !== instanceId) {
+        logReadinessResult({
+          title: "Tailscale URL points to another MDQ server",
+          status: "The public URL is not connected to this server process.",
+          url: info.fullUrl,
+          details: [
+            `Public instance: ${health.instanceId}`,
+            `This instance: ${instanceId}`,
+          ],
+          nextSteps: ["Stop the old process on the published port, then restart MDQ."],
+        });
+      } else {
+        tailscaleHealthVerified = true;
+        logReadinessResult({
+          title: "Tailscale Funnel is ready",
+          status: "The public URL reaches this MDQ server.",
+          url: info.fullUrl,
+          details: [`Local server port: ${boundPort}`],
         });
       }
     }
@@ -338,17 +359,8 @@ async function onListening(): Promise<void> {
       if (tailscaleHealthVerified) {
         console.log(`Verified public host routes to this instance (${instanceId}) after fallback.`);
       } else {
-        try {
-        const response = await fetch(healthUrl, { signal: AbortSignal.timeout(5000) });
-        const payloadUnknown = await response.json().catch(() => ({}));
-        const payload =
-          payloadUnknown && typeof payloadUnknown === "object"
-            ? (payloadUnknown as { instanceId?: unknown })
-            : {};
-        const publicInstanceId =
-          typeof payload.instanceId === "string" ? payload.instanceId : "";
-
-        if (!response.ok || !publicInstanceId) {
+        const health = await checkPublicHealth(info.fullUrl);
+        if (!health.ok) {
           logReadinessResult({
             title: "stopped to avoid opening the wrong classroom link",
             status: "MDQ had to move to a fallback port, but the public URL did not prove that it reaches this server.",
@@ -357,6 +369,7 @@ async function onListening(): Promise<void> {
               `Requested port: ${requestedPort}`,
               `Actual server port: ${boundPort}`,
               `Health check URL: ${healthUrl}`,
+              `Health check failed: ${health.error}`,
             ],
             nextSteps: [
               `Stop the process using port ${requestedPort}, then run npm run try again.`,
@@ -369,7 +382,7 @@ async function onListening(): Promise<void> {
           return;
         }
 
-        if (publicInstanceId !== instanceId) {
+        if (health.instanceId !== instanceId) {
           logReadinessResult({
             title: "stopped because the public URL points to another MDQ server",
             status: "The fallback server started, but the classroom URL is connected to a different running MDQ instance.",
@@ -377,7 +390,7 @@ async function onListening(): Promise<void> {
             details: [
               `Requested port: ${requestedPort}`,
               `Actual server port: ${boundPort}`,
-              `Public instance: ${publicInstanceId}`,
+              `Public instance: ${health.instanceId}`,
               `This instance: ${instanceId}`,
             ],
             nextSteps: [
@@ -392,27 +405,6 @@ async function onListening(): Promise<void> {
         }
 
         console.log(`Verified public host routes to this instance (${instanceId}) after fallback.`);
-        } catch (error) {
-          const message = error instanceof Error ? error.message : "unknown";
-          logReadinessResult({
-            title: "stopped because the public URL could not be checked",
-            status: "MDQ had to move to a fallback port, and it could not confirm that the public URL reaches this server.",
-            url: info.fullUrl,
-            details: [
-              `Requested port: ${requestedPort}`,
-              `Actual server port: ${boundPort}`,
-              `Health check failed: ${message}`,
-            ],
-            nextSteps: [
-              `Stop the process using port ${requestedPort}, then run npm run try again.`,
-              "For local testing only, run: npm run try -- --local-only",
-            ],
-          });
-        httpServer.close(() => {
-          process.exit(1);
-        });
-        return;
-        }
       }
     }
   } catch (e) {

--- a/scripts/try-mdq.sh
+++ b/scripts/try-mdq.sh
@@ -269,6 +269,8 @@ else
   echo
   echo "After you create a session in the instructor screen, mock local students with:"
   echo "  npx tsx scripts/mock-students.ts 20 http://localhost:$PORT_VALUE"
+  echo "or, after copying the session code:"
+  echo "  npx tsx scripts/mock-students.ts <SESSION_CODE> 20 http://localhost:$PORT_VALUE"
 fi
 
 section "Start Server"

--- a/scripts/try-mdq.sh
+++ b/scripts/try-mdq.sh
@@ -1,0 +1,283 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+DEFAULT_PORT="2081"
+PORT_VALUE="${PORT:-$DEFAULT_PORT}"
+MODE="auto"
+SKIP_INSTALL="0"
+SKIP_BUILD="0"
+ASSUME_YES="0"
+
+usage() {
+  cat <<'EOF'
+Usage: npm run try -- [options]
+
+Options:
+  --local-only     Never offer to start Tailscale Funnel.
+  --publish        Offer to start Tailscale Funnel when Tailscale is available.
+  --yes            With --publish, start Funnel without an interactive prompt.
+  --skip-install   Do not run npm install.
+  --skip-build     Do not run npm run build.
+  --help           Show this help.
+
+Environment:
+  PORT             MDQ server port. Defaults to 2081 for this launcher.
+
+Examples:
+  npm run try
+  PORT=3000 npm run try
+  npm run try -- --publish
+  npm run try -- --local-only
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --local-only)
+      MODE="local"
+      ;;
+    --publish)
+      MODE="publish"
+      ;;
+    --yes|-y)
+      ASSUME_YES="1"
+      ;;
+    --skip-install)
+      SKIP_INSTALL="1"
+      ;;
+    --skip-build)
+      SKIP_BUILD="1"
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown option: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+  shift
+done
+
+if ! [[ "$PORT_VALUE" =~ ^[0-9]+$ ]] || [[ "$PORT_VALUE" -lt 1 ]] || [[ "$PORT_VALUE" -gt 65535 ]]; then
+  echo "PORT must be a number between 1 and 65535; got '$PORT_VALUE'." >&2
+  exit 2
+fi
+
+cd "$ROOT_DIR"
+
+section() {
+  printf '\n== %s ==\n' "$1"
+}
+
+have_cmd() {
+  command -v "$1" >/dev/null 2>&1
+}
+
+tailscale_dns_name() {
+  if ! have_cmd tailscale; then
+    return 1
+  fi
+
+  node -e '
+const { execFileSync } = require("child_process");
+try {
+  const raw = execFileSync("tailscale", ["status", "--json"], { encoding: "utf8", timeout: 5000 });
+  const status = JSON.parse(raw);
+  const dns = status && status.Self && typeof status.Self.DNSName === "string"
+    ? status.Self.DNSName.replace(/\.$/, "")
+    : "";
+  if (!dns) process.exit(1);
+  console.log(dns);
+} catch {
+  process.exit(1);
+}
+'
+}
+
+funnel_status_has_port() {
+  local port="$1"
+
+  if ! have_cmd tailscale; then
+    return 1
+  fi
+
+  node -e '
+const { execFileSync } = require("child_process");
+const port = process.argv[1];
+try {
+  const raw = execFileSync("tailscale", ["funnel", "status", "--json"], { encoding: "utf8", timeout: 5000 });
+  const status = JSON.parse(raw);
+  const web = status && typeof status === "object" && status.Web && typeof status.Web === "object"
+    ? status.Web
+    : {};
+  for (const hostConfig of Object.values(web)) {
+    const handlers = hostConfig && typeof hostConfig === "object" && hostConfig.Handlers && typeof hostConfig.Handlers === "object"
+      ? hostConfig.Handlers
+      : {};
+    for (const handler of Object.values(handlers)) {
+      const proxy = handler && typeof handler === "object" && typeof handler.Proxy === "string"
+        ? handler.Proxy
+        : "";
+      if (proxy === `http://127.0.0.1:${port}` || proxy === `http://localhost:${port}`) {
+        process.exit(0);
+      }
+    }
+  }
+  process.exit(1);
+} catch {
+  process.exit(1);
+}
+' "$port"
+}
+
+funnel_public_url_for_port() {
+  local dns="$1"
+  local port="$2"
+
+  if ! have_cmd tailscale; then
+    return 1
+  fi
+
+  node -e '
+const { execFileSync } = require("child_process");
+const dns = process.argv[1];
+const port = process.argv[2];
+try {
+  const raw = execFileSync("tailscale", ["funnel", "status", "--json"], { encoding: "utf8", timeout: 5000 });
+  const status = JSON.parse(raw);
+  const web = status && typeof status === "object" && status.Web && typeof status.Web === "object"
+    ? status.Web
+    : {};
+  for (const [hostKey, hostConfig] of Object.entries(web)) {
+    const handlers = hostConfig && typeof hostConfig === "object" && hostConfig.Handlers && typeof hostConfig.Handlers === "object"
+      ? hostConfig.Handlers
+      : {};
+    for (const handler of Object.values(handlers)) {
+      const proxy = handler && typeof handler === "object" && typeof handler.Proxy === "string"
+        ? handler.Proxy
+        : "";
+      if (proxy !== `http://127.0.0.1:${port}` && proxy !== `http://localhost:${port}`) {
+        continue;
+      }
+      const [, rawPort = "443"] = String(hostKey).split(":");
+      if (rawPort === "443") {
+        console.log(`https://${dns}`);
+      } else {
+        console.log(`http://${dns}:${rawPort}`);
+      }
+      process.exit(0);
+    }
+  }
+  process.exit(1);
+} catch {
+  process.exit(1);
+}
+' "$dns" "$port"
+}
+
+run_funnel() {
+  local port="$1"
+
+  section "Tailscale Funnel"
+  echo "Tailscale is available, but Funnel does not appear to publish MDQ on port $port."
+  echo "MDQ will not automatically change the shared Tailscale Funnel route."
+  echo "This machine already uses the bare Tailscale hostname for other services, so changing it can break clients such as Vimicate."
+  echo
+  echo "For a public classroom URL, use the configured Cloudflare route or set MDQ_PUBLIC_URL to a dedicated hostname."
+  echo "For local/tailnet testing, keep using: npm run try"
+
+  if [[ "$ASSUME_YES" == "1" ]]; then
+    echo
+    echo "--yes was provided, but automatic Funnel publishing is disabled to protect the shared Tailscale hostname."
+  fi
+  return 0
+}
+
+section "Prepare MDQ"
+if [[ "$SKIP_INSTALL" == "1" ]]; then
+  echo "Skipping npm install."
+elif [[ -d node_modules ]]; then
+  echo "Dependencies already present; running npm install to reconcile package-lock changes."
+  npm install
+else
+  echo "Installing dependencies."
+  npm install
+fi
+
+npm run setup:local
+
+if [[ "$SKIP_BUILD" == "1" ]]; then
+  echo "Skipping build."
+else
+  npm run build
+fi
+
+section "Access Mode"
+echo "MDQ will start on port $PORT_VALUE."
+echo "Requested instructor URL: http://localhost:$PORT_VALUE/#/instructor"
+echo "Requested local student URL after creating a session: http://localhost:$PORT_VALUE/#/join/<SESSION_CODE>"
+echo "If that port is occupied, the server may print a fallback port below."
+echo
+
+TAILSCALE_DNS=""
+SERVER_BIND_HOST="${MDQ_BIND_HOST:-${HOST:-}}"
+PUBLIC_URL_OVERRIDE="${MDQ_PUBLIC_URL:-${PUBLIC_URL:-}}"
+DISABLE_TAILSCALE_FOR_SERVER="0"
+if [[ "$MODE" == "local" ]]; then
+  echo "Local-only mode selected. No Tailscale changes will be made."
+elif TAILSCALE_DNS="$(tailscale_dns_name)"; then
+  SERVER_BIND_HOST="${SERVER_BIND_HOST:-127.0.0.1}"
+  echo "Tailscale detected: https://$TAILSCALE_DNS"
+  echo "MDQ will bind to $SERVER_BIND_HOST so Tailscale Funnel can proxy to it without a port conflict."
+
+  if funnel_status_has_port "$PORT_VALUE"; then
+    PUBLIC_URL_OVERRIDE="${PUBLIC_URL_OVERRIDE:-$(funnel_public_url_for_port "$TAILSCALE_DNS" "$PORT_VALUE" || true)}"
+    PUBLIC_URL_OVERRIDE="${PUBLIC_URL_OVERRIDE:-https://$TAILSCALE_DNS}"
+    echo "Funnel already proxies to local port $PORT_VALUE."
+    echo "Public/Tailscale URL after creating a session: $PUBLIC_URL_OVERRIDE/#/join/<SESSION_CODE>"
+  elif [[ "$MODE" == "publish" ]]; then
+    run_funnel "$PORT_VALUE"
+    if funnel_status_has_port "$PORT_VALUE"; then
+      PUBLIC_URL_OVERRIDE="${PUBLIC_URL_OVERRIDE:-$(funnel_public_url_for_port "$TAILSCALE_DNS" "$PORT_VALUE" || true)}"
+      PUBLIC_URL_OVERRIDE="${PUBLIC_URL_OVERRIDE:-https://$TAILSCALE_DNS}"
+      echo "Public/Tailscale URL after creating a session: $PUBLIC_URL_OVERRIDE/#/join/<SESSION_CODE>"
+    else
+      echo "Starting as a local try-out because no safe public Funnel route was configured."
+      PUBLIC_URL_OVERRIDE="${PUBLIC_URL_OVERRIDE:-http://localhost:$PORT_VALUE}"
+      DISABLE_TAILSCALE_FOR_SERVER="1"
+    fi
+  else
+    echo
+    echo "Funnel is not currently proxying to local port $PORT_VALUE."
+    echo "This run will start as a local try-out until you publish Funnel."
+    echo "For a public classroom URL, run:"
+    echo "  npm run try -- --publish"
+    echo "or:"
+    echo "  tailscale funnel --bg --yes localhost:$PORT_VALUE"
+    PUBLIC_URL_OVERRIDE="${PUBLIC_URL_OVERRIDE:-http://localhost:$PORT_VALUE}"
+    DISABLE_TAILSCALE_FOR_SERVER="1"
+  fi
+else
+  echo "Tailscale was not detected or is not signed in."
+  echo "This run is for local appearance testing, projector testing, and mock-student testing."
+  echo "It is not a public classroom URL, and real students off this machine may not be able to connect."
+  echo
+  echo "After you create a session in the instructor screen, mock local students with:"
+  echo "  npx tsx scripts/mock-students.ts 20 http://localhost:$PORT_VALUE"
+fi
+
+section "Start Server"
+echo "Press Ctrl+C to stop MDQ."
+echo
+if [[ "$MODE" == "local" ]]; then
+  MDQ_DISABLE_TAILSCALE=1 PORT="$PORT_VALUE" npm run start --workspace=@mdq/server
+elif [[ "$DISABLE_TAILSCALE_FOR_SERVER" == "1" ]]; then
+  MDQ_DISABLE_TAILSCALE=1 MDQ_PUBLIC_URL="$PUBLIC_URL_OVERRIDE" MDQ_BIND_HOST="$SERVER_BIND_HOST" PORT="$PORT_VALUE" npm run start --workspace=@mdq/server
+else
+  MDQ_PUBLIC_URL="$PUBLIC_URL_OVERRIDE" MDQ_BIND_HOST="$SERVER_BIND_HOST" PORT="$PORT_VALUE" npm run start --workspace=@mdq/server
+fi


### PR DESCRIPTION
## Summary

Adds a guarded one-command try flow for MDQ.

- adds `npm run try`, `try:local`, and `try:publish`
- prepares local runtime folders, builds the app, and starts the server on the try-flow port
- detects local, Tailscale, and configured public URL modes without rewriting shared Tailscale routes automatically
- adds readiness logging and safety checks for fallback ports
- documents the new try flow in the README

## Validation

- `npm run verify:quick`
- branch diff scan for local paths, secrets, committed runtime data, and private quiz data
- local smoke launch of the try flow on an alternate port with `/api/health` returning OK
