### PR TITLE
Bump version to 0.3.4-beta

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mdq",
-  "version": "0.3.3-beta",
+  "version": "0.3.4-beta",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mdq",
-      "version": "0.3.3-beta",
+      "version": "0.3.4-beta",
       "workspaces": [
         "packages/*"
       ],
@@ -9274,7 +9274,7 @@
     },
     "packages/client": {
       "name": "@mdq/client",
-      "version": "0.3.3-beta",
+      "version": "0.3.4-beta",
       "dependencies": {
         "@mdq/shared": "*",
         "react": "^19.2.0",
@@ -9539,7 +9539,7 @@
     },
     "packages/server": {
       "name": "@mdq/server",
-      "version": "0.3.3-beta",
+      "version": "0.3.4-beta",
       "dependencies": {
         "@mdq/shared": "*",
         "cors": "^2.8.5",
@@ -9565,7 +9565,7 @@
     },
     "packages/shared": {
       "name": "@mdq/shared",
-      "version": "0.3.3-beta"
+      "version": "0.3.4-beta"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mdq",
-  "version": "0.3.3-beta",
+  "version": "0.3.4-beta",
   "private": true,
   "workspaces": [
     "packages/*"

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mdq/client",
   "private": true,
-  "version": "0.3.3-beta",
+  "version": "0.3.4-beta",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdq/server",
-  "version": "0.3.3-beta",
+  "version": "0.3.4-beta",
   "private": true,
   "main": "dist/index.js",
   "scripts": {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdq/shared",
-  "version": "0.3.3-beta",
+  "version": "0.3.4-beta",
   "private": true,
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Summary

Bumps MDQ from `0.3.3-beta` to `0.3.4-beta` after the guarded one-command try flow landed.

## Validation

- `npm run verify:quick`
- diff checked for local paths, obvious secrets, runtime data, and private quiz data
