### PR TITLE
Add per-deck presenter note overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -474,6 +474,22 @@ Configuration (in `data/config.json`, or the matching environment variables):
   the operating script, `true` is convenient; the projector never sees the
   instructor screen.
 
+Individual decks can narrow those global settings in the Markdown preamble:
+
+```markdown
+# My talk
+presenter_notes: false
+presenter_notes_default_open: false
+
+---
+```
+
+- `presenter_notes: false` disables the panel and prevents note bodies from
+  being served for that deck. A deck cannot enable presenter notes when the
+  global master switch or instructor authentication is unavailable.
+- `presenter_notes_default_open` overrides the global initial open/closed state
+  for that deck when presenter notes are enabled.
+
 The PDF exporter keeps presenter notes hidden by default; pass
 `--presenter-notes` to include them in a private rehearsal handout.
 

--- a/packages/server/src/__tests__/presenter-notes.test.ts
+++ b/packages/server/src/__tests__/presenter-notes.test.ts
@@ -72,6 +72,13 @@ Nothing to see here.
 ---
 `;
 
+const DECK_WITH_NOTES_DISABLED = DECK_WITH_NOTES.replace(
+  "# Presenter Notes Deck",
+  `# Presenter Notes Deck
+presenter_notes: false
+presenter_notes_default_open: true`,
+);
+
 function writeTempDeck(contents: string): { dir: string; week: string } {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "mdq-pnotes-"));
   fs.writeFileSync(path.join(dir, "talk.md"), contents);
@@ -157,6 +164,27 @@ describe("presenter notes: parser association", () => {
     const last = parsed.quiz!.questions[3];
     expect(last.presenterNotes ?? []).toHaveLength(0);
   });
+
+  it("parses deck-level presenter-note overrides from the preamble", () => {
+    const result = parseQuizMarkdown(DECK_WITH_NOTES_DISABLED, "talk.md");
+    expect(result.errors).toHaveLength(0);
+    expect(result.quiz?.presenterNotes).toBe(false);
+    expect(result.quiz?.presenterNotesDefaultOpen).toBe(true);
+  });
+
+  it("rejects invalid deck-level boolean metadata", () => {
+    const result = parseQuizMarkdown(
+      DECK_WITH_NOTES.replace(
+        "# Presenter Notes Deck",
+        `# Presenter Notes Deck
+presenter_notes: sometimes`,
+      ),
+      "talk.md",
+    );
+    expect(result.errors.map((error) => error.detail)).toContain(
+      "Invalid presenter_notes: sometimes (expected true or false)",
+    );
+  });
 });
 
 describe("presenter notes: instructor endpoint", () => {
@@ -213,6 +241,44 @@ describe("presenter notes: instructor endpoint", () => {
     expect(res.body.items[0].questionIndex).toBe(0);
     expect(res.body.items[0].notes[0].bodyHtml).toContain("only the presenter sees this");
     expect(res.body.items[3].notes).toEqual([]);
+  });
+
+  it("allows a deck to disable globally enabled presenter notes", async () => {
+    const { dir, week } = writeTempDeck(DECK_WITH_NOTES_DISABLED);
+    const app = createApp({ quizDir: dir, presenterNotes: true, presenterNotesDefaultOpen: true });
+    const agent = await authedAgent(app);
+    const res = await agent.get(`/api/deck/${week}/presenter-notes`);
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ enabled: false, defaultOpen: false, items: [] });
+    expect(JSON.stringify(res.body)).not.toContain("only the presenter sees this");
+  });
+
+  it("allows a deck to override the global default-open setting", async () => {
+    const contents = DECK_WITH_NOTES.replace(
+      "# Presenter Notes Deck",
+      `# Presenter Notes Deck
+presenter_notes_default_open: false`,
+    );
+    const { dir, week } = writeTempDeck(contents);
+    const app = createApp({ quizDir: dir, presenterNotes: true, presenterNotesDefaultOpen: true });
+    const agent = await authedAgent(app);
+    const res = await agent.get(`/api/deck/${week}/presenter-notes`);
+    expect(res.status).toBe(200);
+    expect(res.body.enabled).toBe(true);
+    expect(res.body.defaultOpen).toBe(false);
+  });
+
+  it("does not let a deck enable notes when the global privacy gate is off", async () => {
+    const contents = DECK_WITH_NOTES.replace(
+      "# Presenter Notes Deck",
+      `# Presenter Notes Deck
+presenter_notes: true`,
+    );
+    const { dir, week } = writeTempDeck(contents);
+    const app = createApp({ quizDir: dir, presenterNotes: false });
+    const agent = await authedAgent(app);
+    const res = await agent.get(`/api/deck/${week}/presenter-notes`);
+    expect(res.body).toEqual({ enabled: false, defaultOpen: false, items: [] });
   });
 
   it("404s for an unknown deck when enabled (authed)", async () => {

--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -552,11 +552,20 @@ export function createApp(quizDirOrOpts?: string | AppOptions) {
     if (!quiz) {
       return res.status(404).json({ error: `Deck not found: ${req.params.week}` });
     }
+    // A deck may opt out of a globally enabled notes feature. It cannot opt in
+    // when the global privacy gate or instructor authentication is unavailable.
+    if (quiz.presenterNotes === false) {
+      return res.json({ enabled: false, defaultOpen: false, items: [] });
+    }
     const items = quiz.questions.map((question, index) => ({
       questionIndex: question.index ?? index,
       notes: question.presenterNotes ?? [],
     }));
-    return res.json({ enabled: true, defaultOpen: presenterNotesDefaultOpen, items });
+    return res.json({
+      enabled: true,
+      defaultOpen: quiz.presenterNotesDefaultOpen ?? presenterNotesDefaultOpen,
+      items,
+    });
   };
   app.get(API.DECK_PRESENTER_NOTES, requireInstructorAuth, getPresenterNotesHandler);
 

--- a/packages/server/src/parser.ts
+++ b/packages/server/src/parser.ts
@@ -57,6 +57,13 @@ export function parseQuizMarkdown(markdown: string, sourceFile: string): ParseRe
   const errors: QuizParseError[] = [];
 
   const title = extractDeckTitle(markdown);
+  const presenterNotes = extractDeckBooleanMetadata(markdown, "presenter_notes", sourceFile, errors);
+  const presenterNotesDefaultOpen = extractDeckBooleanMetadata(
+    markdown,
+    "presenter_notes_default_open",
+    sourceFile,
+    errors,
+  );
 
   // Extract deck key from filename (e.g., "week01.md" -> "week01", "featured-demo.md" -> "featured-demo")
   const sourceStem = sourceFile.replace(/^.*[\\/]/, "").replace(/\.md$/i, "").toLowerCase();
@@ -92,6 +99,8 @@ export function parseQuizMarkdown(markdown: string, sourceFile: string): ParseRe
   const quiz: Quiz = {
     week,
     title,
+    presenterNotes,
+    presenterNotesDefaultOpen,
     questions,
     sourceFile,
   };
@@ -152,6 +161,32 @@ function stripOptionalQuotes(value: string): string {
     return trimmed.slice(1, -1).trim();
   }
   return trimmed;
+}
+
+function extractDeckBooleanMetadata(
+  markdown: string,
+  key: "presenter_notes" | "presenter_notes_default_open",
+  sourceFile: string,
+  errors: QuizParseError[],
+): boolean | undefined {
+  const preamble = markdown.split(/^---+\s*$/m, 1)[0] || markdown;
+  const match = preamble.match(new RegExp(`^${key}:\\s*(.*?)\\s*$`, "im"));
+  if (!match) return undefined;
+
+  const value = stripOptionalQuotes(match[1]).toLowerCase();
+  if (value === "true") return true;
+  if (value === "false") return false;
+
+  const lineNumber = preamble.slice(0, match.index).split("\n").length;
+  errors.push(
+    new QuizParseError(
+      sourceFile,
+      -1,
+      `Invalid ${key}: ${match[1].trim()} (expected true or false)`,
+      lineNumber,
+    ),
+  );
+  return undefined;
 }
 
 /**

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -308,6 +308,10 @@ export interface Question {
 export interface Quiz {
   week: string;
   title: string;
+  /** Optional per-deck override. `false` disables globally enabled presenter notes. */
+  presenterNotes?: boolean;
+  /** Optional per-deck override for the panel's initial expanded state. */
+  presenterNotesDefaultOpen?: boolean;
   questions: Question[];
   sourceFile: string;
 }


### PR DESCRIPTION
## Summary

- Add per-deck `presenter_notes` and `presenter_notes_default_open` Markdown settings.
- Keep the global presenter-notes switch and instructor authentication as master privacy gates.
- Allow a deck to disable presenter notes or override the panel's initial open state.
- Document the settings and their privacy behavior.

## Privacy behavior

- A deck can narrow the global configuration, but cannot enable presenter notes when the global switch is off.
- Presenter-note bodies remain available only through the authenticated instructor endpoint.
- Public deck and audience socket payloads do not expose presenter notes.

## Validation

- Presenter-notes test suite: 21 tests passed.
- Full MDQ server suite in the integrated checkout: 260 tests passed.
- TypeScript typecheck passed.
- Production build passed.
- `git diff --check` passed.

## Dependency

This is a stacked PR based on #39, which introduces the presenter-notes capability. Retarget this PR to `main` after #39 lands.
