### PR TITLE
Add per-deck presentation themes

### DIFF
--- a/README.md
+++ b/README.md
@@ -474,6 +474,22 @@ Configuration (in `data/config.json`, or the matching environment variables):
   the operating script, `true` is convenient; the projector never sees the
   instructor screen.
 
+Individual decks can narrow those global settings in the Markdown preamble:
+
+```markdown
+# My talk
+presenter_notes: false
+presenter_notes_default_open: false
+
+---
+```
+
+- `presenter_notes: false` disables the panel and prevents note bodies from
+  being served for that deck. A deck cannot enable presenter notes when the
+  global master switch or instructor authentication is unavailable.
+- `presenter_notes_default_open` overrides the global initial open/closed state
+  for that deck when presenter notes are enabled.
+
 The PDF exporter keeps presenter notes hidden by default; pass
 `--presenter-notes` to include them in a private rehearsal handout.
 

--- a/README.md
+++ b/README.md
@@ -126,6 +126,20 @@ Optional local runtime settings live in `data/config.json` (copy from
 `data/config.example.json`). The tracked example includes `theme`, which accepts
 `dark` or `light`.
 
+Individual decks can override that global fallback in the Markdown preamble:
+
+```markdown
+# My Deck
+theme: light
+
+---
+```
+
+`theme` accepts only `light` or `dark` (case-insensitive, with optional quotes).
+When it is omitted, every instructor, student, and projector view uses the
+global runtime theme. The PDF export theme remains controlled independently by
+its `--theme` command-line option.
+
 Build and run the app:
 
 ```bash
@@ -232,7 +246,7 @@ Tip for classroom privacy and mobility: project a separate presentation view fro
 ### 2) instructor live surface controls
 
 - The deck picker shows each deck summary as separate quiz question and slide counts, for example `(22 questions, 17 slides)`.
-- The live surface uses a dark presentation theme by default: deep background, restrained accents, rounded controls, and clean dot bullets.
+- The live surface uses the configured global presentation theme by default; a deck-level `theme: light` or `theme: dark` preamble setting overrides it for that session.
 - `Prev` and `Next` stay pinned together near the top-left of the live surface so their click targets do not drift when other controls appear or disappear.
 - In live mode, `Next` includes the next item's markdown heading inside the button. In review mode, `Next` stays a plain button.
 - `End Session` remains available from the live controls and opens a confirmation dialog before closing the room. The dialog shows how many quiz questions and slides are left.

--- a/packages/client/src/App.tsx
+++ b/packages/client/src/App.tsx
@@ -5,6 +5,8 @@ import StudentView from "./views/StudentView";
 import InstructorLoginPrompt from "./components/InstructorLoginPrompt";
 import { fetchInstructorSessionStatus } from "./hooks/api";
 import type { RuntimeClientConfig } from "./hooks/api";
+import type { DeckTheme } from "@mdq/shared";
+import { applyClientTheme, resolveClientTheme } from "./theme";
 
 const DEFAULT_INSTRUCTOR_ROUTE_SEGMENT = "instructor";
 
@@ -116,6 +118,7 @@ function getRoute(): AppRoute {
 export default function App({ runtimeConfig = {} }: { runtimeConfig?: RuntimeClientConfig }) {
   const [route, setRoute] = useState(getRoute);
   const autoGenerateStudentIds = runtimeConfig.autoGenerateStudentIds === true;
+  const defaultTheme = resolveClientTheme(runtimeConfig.theme);
 
   useEffect(() => {
     const onHash = () => setRoute(getRoute());
@@ -123,16 +126,20 @@ export default function App({ runtimeConfig = {} }: { runtimeConfig?: RuntimeCli
     return () => window.removeEventListener("hashchange", onHash);
   }, []);
 
+  useEffect(() => {
+    if (route.page === "home") applyClientTheme(defaultTheme);
+  }, [defaultTheme, route.page]);
+
   if (route.page === "instructor") {
-    return <InstructorGate returnTo={route.next} authContext={route.authContext} autoGenerateStudentIds={autoGenerateStudentIds} />;
+    return <InstructorGate returnTo={route.next} authContext={route.authContext} autoGenerateStudentIds={autoGenerateStudentIds} defaultTheme={defaultTheme} />;
   }
 
   if (route.page === "join") {
-    return <StudentView initialSessionCode={route.param} autoGenerateStudentIds={autoGenerateStudentIds} />;
+    return <StudentView initialSessionCode={route.param} autoGenerateStudentIds={autoGenerateStudentIds} defaultTheme={defaultTheme} />;
   }
 
   if (route.page === "student") {
-    return <StudentView initialSessionId={route.param} autoGenerateStudentIds={autoGenerateStudentIds} />;
+    return <StudentView initialSessionId={route.param} autoGenerateStudentIds={autoGenerateStudentIds} defaultTheme={defaultTheme} />;
   }
 
   if (route.page === "presentation" && route.param) {
@@ -144,6 +151,7 @@ export default function App({ runtimeConfig = {} }: { runtimeConfig?: RuntimeCli
           authContext: "presentation",
         })}
         autoGenerateStudentIds={autoGenerateStudentIds}
+        defaultTheme={defaultTheme}
       />
     );
   }
@@ -204,14 +212,20 @@ function InstructorGate({
   returnTo,
   authContext,
   autoGenerateStudentIds,
+  defaultTheme,
 }: {
   returnTo?: string;
   authContext?: AuthContext;
   autoGenerateStudentIds: boolean;
+  defaultTheme: DeckTheme;
 }) {
   const [checking, setChecking] = useState(true);
   const [authenticated, setAuthenticated] = useState(false);
   const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    applyClientTheme(defaultTheme);
+  }, [defaultTheme]);
 
   useEffect(() => {
     fetchInstructorSessionStatus()
@@ -247,7 +261,7 @@ function InstructorGate({
   }
 
   if (authenticated) {
-    return <InstructorView autoGenerateStudentIds={autoGenerateStudentIds} />;
+    return <InstructorView autoGenerateStudentIds={autoGenerateStudentIds} defaultTheme={defaultTheme} />;
   }
 
   const isPresentationLogin = authContext === "presentation";

--- a/packages/client/src/hooks/api.ts
+++ b/packages/client/src/hooks/api.ts
@@ -1,6 +1,7 @@
 import { API } from "@mdq/shared";
 import type {
   AccessInfo,
+  DeckTheme,
   PresenterNotesResponse,
   QuestionOpenPayload,
   QuestionType,
@@ -20,6 +21,8 @@ function apiPath(template: string, params: Record<string, string> = {}): string 
 export interface DeckSummary {
   week: string;
   title: string;
+  /** Effective theme after applying the runtime fallback. */
+  theme: DeckTheme;
   /** Total live items, including slides. Kept for progress/restore compatibility. */
   questionCount: number;
   /** Interactive quiz/poll/open-response items, excluding slides. */
@@ -38,6 +41,7 @@ export interface CreateSessionResponse {
   sessionId: string;
   sessionCode: string;
   joinUrl: string;
+  theme: DeckTheme;
   questionHeadings: string[];
   questionSummaries: QuestionSummary[];
 }
@@ -46,6 +50,7 @@ export interface SessionRestoreResponse {
   sessionId: string;
   sessionCode: string;
   week: string;
+  theme: DeckTheme;
   state: string;
   currentQuestionIndex: number;
   questionCount: number;
@@ -59,6 +64,7 @@ export interface PresentationSessionResponse {
   sessionId: string;
   sessionCode: string;
   week: string;
+  theme: DeckTheme;
   state: string;
   questionCount: number;
   questionHeadings: string[];

--- a/packages/client/src/hooks/useSocket.ts
+++ b/packages/client/src/hooks/useSocket.ts
@@ -21,6 +21,7 @@ import type {
   SlideLiveEmbed,
   SlideVideo,
   SlideReference,
+  DeckTheme,
 } from "@mdq/shared";
 import { SocketEvents } from "@mdq/shared";
 
@@ -32,6 +33,8 @@ interface StoredSession {
   sessionId: string;
   studentId: string;
   sessionToken: string;
+  sessionWeek?: string;
+  sessionTheme?: DeckTheme;
 }
 
 function appendAnsweredQuestion(current: number[], questionIndex: number): number[] {
@@ -49,7 +52,11 @@ function loadStoredSession(): StoredSession | null {
 }
 
 function saveStoredSession(data: StoredSession) {
-  localStorage.setItem(STORAGE_KEY, JSON.stringify(data));
+  const existing = loadStoredSession();
+  const retainedMetadata = existing?.sessionId === data.sessionId
+    ? { sessionWeek: existing.sessionWeek, sessionTheme: existing.sessionTheme }
+    : {};
+  localStorage.setItem(STORAGE_KEY, JSON.stringify({ ...retainedMetadata, ...data }));
 }
 
 function clearStoredSession() {

--- a/packages/client/src/main.tsx
+++ b/packages/client/src/main.tsx
@@ -5,20 +5,17 @@ import "./theme.css";
 import App from "./App";
 import { fetchRuntimeClientConfig } from "./hooks/api";
 import type { RuntimeClientConfig } from "./hooks/api";
-
-function applyRuntimeTheme(theme: unknown): void {
-  document.documentElement.dataset.theme = theme === "light" ? "light" : "dark";
-}
+import { applyClientTheme } from "./theme";
 
 async function bootstrap(): Promise<void> {
-  applyRuntimeTheme("dark");
+  applyClientTheme("dark");
   let runtimeConfig: RuntimeClientConfig = {};
 
   try {
     runtimeConfig = await fetchRuntimeClientConfig();
-    applyRuntimeTheme(runtimeConfig.theme);
+    applyClientTheme(runtimeConfig.theme);
   } catch {
-    applyRuntimeTheme("dark");
+    applyClientTheme("dark");
   }
 
   createRoot(document.getElementById("root")!).render(

--- a/packages/client/src/theme.ts
+++ b/packages/client/src/theme.ts
@@ -1,0 +1,14 @@
+import type { DeckTheme } from "@mdq/shared";
+
+export const DEFAULT_CLIENT_THEME: DeckTheme = "dark";
+
+export function resolveClientTheme(theme: unknown, fallback: DeckTheme = DEFAULT_CLIENT_THEME): DeckTheme {
+  if (theme === "light" || theme === "dark") return theme;
+  return fallback;
+}
+
+export function applyClientTheme(theme: unknown, fallback: DeckTheme = DEFAULT_CLIENT_THEME): DeckTheme {
+  const resolved = resolveClientTheme(theme, fallback);
+  document.documentElement.dataset.theme = resolved;
+  return resolved;
+}

--- a/packages/client/src/views/InstructorView.tsx
+++ b/packages/client/src/views/InstructorView.tsx
@@ -21,7 +21,8 @@ import {
   type CreateSessionResponse,
   type SessionRestoreResponse,
 } from "../hooks/api";
-import type { AccessInfo, FoldoutNote, QuestionType, SessionState } from "@mdq/shared";
+import type { AccessInfo, DeckTheme, FoldoutNote, QuestionType, SessionState } from "@mdq/shared";
+import { applyClientTheme } from "../theme";
 import Timer from "../components/Timer";
 import Leaderboard from "../components/Leaderboard";
 import OpenResponseList from "../components/OpenResponseList";
@@ -118,7 +119,13 @@ function saveInstructorRestore(restore: StoredInstructorRestore): void {
   }
 }
 
-export default function InstructorView({ autoGenerateStudentIds = false }: { autoGenerateStudentIds?: boolean }) {
+export default function InstructorView({
+  autoGenerateStudentIds = false,
+  defaultTheme = "dark",
+}: {
+  autoGenerateStudentIds?: boolean;
+  defaultTheme?: DeckTheme;
+}) {
   // Setup state
   const [decks, setDecks] = useState<DeckSummary[]>([]);
   const [selectedWeek, setSelectedWeek] = useState<string>("");
@@ -134,6 +141,7 @@ export default function InstructorView({ autoGenerateStudentIds = false }: { aut
   const [questionHeadings, setQuestionHeadings] = useState<string[]>([]);
   const [questionSummaries, setQuestionSummaries] = useState<QuestionSummary[]>([]);
   const [quizLabel, setQuizLabel] = useState("");
+  const [sessionTheme, setSessionTheme] = useState<DeckTheme | undefined>();
   const [restoreNotice, setRestoreNotice] = useState<string | null>(null);
   const [restoredQuestionCache, setRestoredQuestionCache] = useState<Record<number, QuestionState>>({});
   const [restoredRevealCache, setRestoredRevealCache] = useState<Record<number, RevealState>>({});
@@ -221,6 +229,7 @@ export default function InstructorView({ autoGenerateStudentIds = false }: { aut
           sessionId: snapshot.sessionId,
           sessionCode: snapshot.sessionCode,
           joinUrl: `/join/${snapshot.sessionCode}`,
+          theme: snapshot.theme,
           questionHeadings: snapshot.questionHeadings || [],
           questionSummaries: snapshot.questionSummaries || [],
         };
@@ -231,6 +240,7 @@ export default function InstructorView({ autoGenerateStudentIds = false }: { aut
         setQuestionHeadings(snapshot.questionHeadings || []);
         setQuestionSummaries(snapshot.questionSummaries || []);
         setQuizLabel(formatQuizLabel(snapshot.week));
+        setSessionTheme(snapshot.theme);
         setRestoredQuestionCache(
           Object.fromEntries(
             (snapshot.reviewQuestions || []).map((question) => {
@@ -308,6 +318,7 @@ export default function InstructorView({ autoGenerateStudentIds = false }: { aut
       setQuestionHeadings(info.questionHeadings || []);
       setQuestionSummaries(info.questionSummaries || []);
       setQuizLabel(formatQuizLabel(deck?.week || selectedWeek));
+      setSessionTheme(info.theme);
       setRestoreNotice(null);
       setPhase("lobby");
 
@@ -368,6 +379,7 @@ export default function InstructorView({ autoGenerateStudentIds = false }: { aut
     setQuestionHeadings([]);
     setQuestionSummaries([]);
     setQuizLabel("");
+    setSessionTheme(undefined);
     setRestoreNotice(null);
     setErrorMsg(null);
     setPhase("setup");
@@ -375,6 +387,9 @@ export default function InstructorView({ autoGenerateStudentIds = false }: { aut
 
   const sid = sessionInfo?.sessionId ?? "";
   const selectedDeck = decks.find((deck) => deck.week === selectedWeek);
+  useEffect(() => {
+    applyClientTheme(sessionTheme ?? selectedDeck?.theme, defaultTheme);
+  }, [defaultTheme, selectedDeck?.theme, sessionTheme]);
   const filteredDecks = decks.filter((deck) => {
     const query = deckFilter.trim().toLowerCase();
     if (!query) return true;

--- a/packages/client/src/views/PresentationView.tsx
+++ b/packages/client/src/views/PresentationView.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from "react";
-import type { SessionState } from "@mdq/shared";
+import type { DeckTheme, SessionState } from "@mdq/shared";
 import InstructorLoginPrompt from "../components/InstructorLoginPrompt";
 import { fetchPresentationSession, type PresentationSessionResponse } from "../hooks/api";
 import { useSocket, type QuestionState, type RevealState } from "../hooks/useSocket";
@@ -14,6 +14,7 @@ import LiveSurface from "../components/LiveSurface";
 import ResponsiveQuizSurface from "../components/ResponsiveQuizSurface";
 import SlideContent, { SlideContentBody } from "../components/SlideContent";
 import { getQuestionModeText } from "../questionMode";
+import { applyClientTheme } from "../theme";
 
 const EMPTY_QUESTION_HEADINGS: string[] = [];
 
@@ -36,15 +37,21 @@ export default function PresentationView({
   sessionId,
   loginHref,
   autoGenerateStudentIds = false,
+  defaultTheme = "dark",
 }: {
   sessionId: string;
   loginHref: string;
   autoGenerateStudentIds?: boolean;
+  defaultTheme?: DeckTheme;
 }) {
   const [meta, setMeta] = useState<PresentationSessionResponse | null>(null);
   const [loading, setLoading] = useState(true);
   const [errorMsg, setErrorMsg] = useState<string | null>(null);
   const sock = useSocket(meta ? sessionId : null, "presentation");
+
+  useEffect(() => {
+    applyClientTheme(meta?.theme, defaultTheme);
+  }, [defaultTheme, meta?.theme]);
 
   useEffect(() => {
     let cancelled = false;

--- a/packages/client/src/views/StudentView.tsx
+++ b/packages/client/src/views/StudentView.tsx
@@ -2,7 +2,7 @@ import { useState, useCallback, useEffect, useRef } from "react";
 import { useSocket } from "../hooks/useSocket";
 import type { QuestionState, RevealState } from "../hooks/useSocket";
 import { API } from "@mdq/shared";
-import type { SessionState } from "@mdq/shared";
+import type { DeckTheme, SessionState } from "@mdq/shared";
 import Timer from "../components/Timer";
 import Leaderboard from "../components/Leaderboard";
 import DistributionChart from "../components/DistributionChart";
@@ -10,6 +10,7 @@ import InlineMarkdownText from "../components/InlineMarkdownText";
 import QuizHtml from "../components/QuizHtml";
 import SlideContent from "../components/SlideContent";
 import { getQuestionModeText } from "../questionMode";
+import { applyClientTheme, resolveClientTheme } from "../theme";
 
 function formatQuizLabel(quizKey: string): string {
   const normalized = quizKey.trim();
@@ -52,10 +53,12 @@ export default function StudentView({
   initialSessionCode,
   initialSessionId,
   autoGenerateStudentIds = false,
+  defaultTheme = "dark",
 }: {
   initialSessionCode?: string;
   initialSessionId?: string;
   autoGenerateStudentIds?: boolean;
+  defaultTheme?: DeckTheme;
 }) {
   const normalizeSessionCode = useCallback(
     (value: string) => value.toUpperCase().replace(/[^A-Z0-9]/g, "").slice(0, 6),
@@ -68,6 +71,7 @@ export default function StudentView({
   const [displayName, setDisplayName] = useState("");
   const [sessionId, setSessionId] = useState<string | null>(null);
   const [quizKey, setQuizKey] = useState<string | null>(null);
+  const [sessionTheme, setSessionTheme] = useState<DeckTheme>(defaultTheme);
   const [joinError, setJoinError] = useState<string | null>(null);
   const [joining, setJoining] = useState(false);
   const [completed, setCompleted] = useState(false);
@@ -102,6 +106,35 @@ export default function StudentView({
   const sock = useSocket(sessionId, "student");
   const { connected, sessionToken, joinSession, error: sockError } = sock;
 
+  useEffect(() => {
+    applyClientTheme(sessionTheme, defaultTheme);
+  }, [defaultTheme, sessionTheme]);
+
+  // Resolve QR/join links early so the join form itself uses the deck theme.
+  useEffect(() => {
+    if (!initialSessionCode) return;
+    let cancelled = false;
+    setSessionTheme(defaultTheme);
+    setQuizKey(null);
+    const normalizedCode = normalizeSessionCode(initialSessionCode);
+    fetch(API.SESSION_BY_CODE.replace(":code", normalizedCode))
+      .then(async (response) => {
+        if (!response.ok) return null;
+        return response.json() as Promise<{ week?: string; theme?: DeckTheme }>;
+      })
+      .then((data) => {
+        if (cancelled || !data) return;
+        setSessionTheme(resolveClientTheme(data.theme, defaultTheme));
+        if (typeof data.week === "string" && data.week.trim()) setQuizKey(data.week);
+      })
+      .catch(() => {
+        // The submit path reports lookup errors; theme preloading is best-effort.
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [defaultTheme, initialSessionCode, normalizeSessionCode]);
+
   // Try to restore session from localStorage on mount
   useEffect(() => {
     try {
@@ -109,6 +142,9 @@ export default function StudentView({
       const targetSessionId = (initialSessionId || "").trim();
       if (raw) {
         const stored = JSON.parse(raw);
+        const restoresStoredSession = targetSessionId
+          ? stored.sessionId === targetSessionId
+          : !initialSessionCode && Boolean(stored.sessionId);
         if (targetSessionId && stored.sessionId === targetSessionId) {
           setSessionId(stored.sessionId);
           setStudentId(stored.studentId || "");
@@ -122,8 +158,11 @@ export default function StudentView({
         if (initialSessionCode && stored.studentId) {
           setStudentId(stored.studentId);
         }
-        if (typeof stored.sessionWeek === "string" && stored.sessionWeek.trim().length > 0) {
+        if (restoresStoredSession && typeof stored.sessionWeek === "string" && stored.sessionWeek.trim().length > 0) {
           setQuizKey(stored.sessionWeek);
+        }
+        if (restoresStoredSession) {
+          setSessionTheme(resolveClientTheme(stored.sessionTheme, defaultTheme));
         }
       } else if (targetSessionId) {
         setSessionId(targetSessionId);
@@ -132,13 +171,14 @@ export default function StudentView({
       // ignore
     }
     setCompleted(false);
-  }, [initialSessionCode, initialSessionId]);
+  }, [defaultTheme, initialSessionCode, initialSessionId]);
 
   const handleDone = useCallback(() => {
     clearSessionArtifacts();
     sock.disconnect();
     setCompleted(true);
-  }, [sock]);
+    setSessionTheme(defaultTheme);
+  }, [defaultTheme, sock]);
 
   // Handle join: first resolve session code to sessionId, then connect socket
   const handleJoin = useCallback(async () => {
@@ -167,11 +207,14 @@ export default function StudentView({
           clearSessionArtifacts();
           setSessionId(null);
           setQuizKey(null);
+          setSessionTheme(defaultTheme);
         }
         throw new Error(data.error || "Session not found. Check the code and try again.");
       }
-      const data: { sessionId: string; week?: string } = await res.json();
+      const data: { sessionId: string; week?: string; theme?: DeckTheme } = await res.json();
+      const resolvedTheme = resolveClientTheme(data.theme, defaultTheme);
       setSessionId(data.sessionId);
+      setSessionTheme(resolvedTheme);
       if (typeof data.week === "string" && data.week.trim().length > 0) {
         setQuizKey(data.week);
       }
@@ -188,6 +231,7 @@ export default function StudentView({
           sessionId: data.sessionId,
           studentId: trimmedStudentId,
           sessionWeek: data.week,
+          sessionTheme: resolvedTheme,
           sessionToken:
             (() => {
               try {
@@ -217,7 +261,7 @@ export default function StudentView({
       setJoinError(e instanceof Error ? e.message : "Failed to join");
       setJoining(false);
     }
-  }, [autoGenerateStudentIds, code, studentId, displayName, normalizeSessionCode]);
+  }, [autoGenerateStudentIds, code, defaultTheme, studentId, displayName, normalizeSessionCode]);
 
   // When socket connects and we have pending join, emit student:join
   useEffect(() => {

--- a/packages/server/src/__tests__/client-theme-contract.test.ts
+++ b/packages/server/src/__tests__/client-theme-contract.test.ts
@@ -6,6 +6,30 @@ const read = (rel: string): string =>
   fs.readFileSync(path.join(clientSrc, rel), "utf-8");
 
 describe("client light-theme contract", () => {
+  describe("per-deck theme application", () => {
+    const theme = read("theme.ts");
+    const instructor = read("views/InstructorView.tsx");
+    const student = read("views/StudentView.tsx");
+    const presentation = read("views/PresentationView.tsx");
+    const socket = read("hooks/useSocket.ts");
+
+    it("normalizes and applies only supported themes", () => {
+      expect(theme).toContain('theme === "light" || theme === "dark"');
+      expect(theme).toContain("document.documentElement.dataset.theme = resolved");
+    });
+
+    it("applies deck themes to instructor, student, and projector views", () => {
+      expect(instructor).toContain("sessionTheme ?? selectedDeck?.theme");
+      expect(student).toContain("resolveClientTheme(data.theme, defaultTheme)");
+      expect(presentation).toContain("applyClientTheme(meta?.theme, defaultTheme)");
+    });
+
+    it("retains the deck theme across student socket reconnection", () => {
+      expect(socket).toContain("sessionTheme?: DeckTheme");
+      expect(socket).toContain("sessionTheme: existing.sessionTheme");
+    });
+  });
+
   describe("theme.css end-session dialog", () => {
     const css = read("theme.css");
 

--- a/packages/server/src/__tests__/deck-theme.test.ts
+++ b/packages/server/src/__tests__/deck-theme.test.ts
@@ -1,0 +1,70 @@
+import fs from "fs";
+import os from "os";
+import path from "path";
+import request from "supertest";
+import { createApp } from "../app";
+import { clearAllSessions } from "../session";
+import { parseQuizMarkdown } from "../parser";
+
+const QUESTION = `
+---
+
+## Check
+
+**Ready?**
+
+A. Yes
+B. No
+
+> Correct Answer: A
+> Overall Feedback: Ready.
+
+---
+`;
+
+function deck(title: string, theme?: string): string {
+  return `# ${title}\n${theme ? `theme: ${theme}\n` : ""}${QUESTION}`;
+}
+
+describe("per-deck theme", () => {
+  afterEach(() => clearAllSessions());
+
+  it("parses light and dark overrides case-insensitively", () => {
+    expect(parseQuizMarkdown(deck("Light", "LIGHT"), "light.md").quiz?.theme).toBe("light");
+    expect(parseQuizMarkdown(deck("Dark", "'dark'"), "dark.md").quiz?.theme).toBe("dark");
+    expect(parseQuizMarkdown(deck("Fallback"), "fallback.md").quiz?.theme).toBeUndefined();
+  });
+
+  it("reports invalid theme metadata at deck level", () => {
+    const result = parseQuizMarkdown(deck("Invalid", "sepia"), "invalid.md");
+    expect(result.errors.map((error) => error.detail)).toContain(
+      "Invalid theme: sepia (expected dark or light)",
+    );
+  });
+
+  it("delivers the effective theme on deck and session endpoints", async () => {
+    const quizDir = fs.mkdtempSync(path.join(os.tmpdir(), "mdq-theme-"));
+    fs.writeFileSync(path.join(quizDir, "light.md"), deck("Light", "light"));
+    fs.writeFileSync(path.join(quizDir, "fallback.md"), deck("Fallback"));
+    const app = createApp({ quizDir, theme: "dark" });
+
+    const decks = await request(app).get("/api/decks").expect(200);
+    expect(decks.body.find((item: { week: string }) => item.week === "light").theme).toBe("light");
+    expect(decks.body.find((item: { week: string }) => item.week === "fallback").theme).toBe("dark");
+
+    const deckResponse = await request(app).get("/api/deck/light").expect(200);
+    expect(deckResponse.body.theme).toBe("light");
+
+    const created = await request(app).post("/api/session").send({ week: "light" }).expect(201);
+    expect(created.body.theme).toBe("light");
+
+    const lookup = await request(app).get(`/api/session/by-code/${created.body.sessionCode}`).expect(200);
+    expect(lookup.body.theme).toBe("light");
+
+    const restored = await request(app).get(`/api/session/${created.body.sessionId}/state`).expect(200);
+    expect(restored.body.theme).toBe("light");
+
+    const presentation = await request(app).get(`/api/session/${created.body.sessionId}/presentation`).expect(200);
+    expect(presentation.body.theme).toBe("light");
+  });
+});

--- a/packages/server/src/__tests__/presenter-notes.test.ts
+++ b/packages/server/src/__tests__/presenter-notes.test.ts
@@ -313,7 +313,7 @@ presenter_notes: true`,
     const app = createApp({ quizDir: dir, presenterNotes: true });
     const res = await request(app).get(`/api/deck/${week}`);
     expect(res.status).toBe(200);
-    expect(Object.keys(res.body).sort()).toEqual(["questionCount", "title", "week"]);
+    expect(Object.keys(res.body).sort()).toEqual(["questionCount", "theme", "title", "week"]);
     expect(JSON.stringify(res.body)).not.toContain("presenter");
   });
 });

--- a/packages/server/src/__tests__/presenter-notes.test.ts
+++ b/packages/server/src/__tests__/presenter-notes.test.ts
@@ -72,6 +72,13 @@ Nothing to see here.
 ---
 `;
 
+const DECK_WITH_NOTES_DISABLED = DECK_WITH_NOTES.replace(
+  "# Presenter Notes Deck",
+  `# Presenter Notes Deck
+presenter_notes: false
+presenter_notes_default_open: true`,
+);
+
 function writeTempDeck(contents: string): { dir: string; week: string } {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "mdq-pnotes-"));
   fs.writeFileSync(path.join(dir, "talk.md"), contents);
@@ -157,6 +164,27 @@ describe("presenter notes: parser association", () => {
     const last = parsed.quiz!.questions[3];
     expect(last.presenterNotes ?? []).toHaveLength(0);
   });
+
+  it("parses deck-level presenter-note overrides from the preamble", () => {
+    const result = parseQuizMarkdown(DECK_WITH_NOTES_DISABLED, "talk.md");
+    expect(result.errors).toHaveLength(0);
+    expect(result.quiz?.presenterNotes).toBe(false);
+    expect(result.quiz?.presenterNotesDefaultOpen).toBe(true);
+  });
+
+  it("rejects invalid deck-level boolean metadata", () => {
+    const result = parseQuizMarkdown(
+      DECK_WITH_NOTES.replace(
+        "# Presenter Notes Deck",
+        `# Presenter Notes Deck
+presenter_notes: sometimes`,
+      ),
+      "talk.md",
+    );
+    expect(result.errors.map((error) => error.detail)).toContain(
+      "Invalid presenter_notes: sometimes (expected true or false)",
+    );
+  });
 });
 
 describe("presenter notes: instructor endpoint", () => {
@@ -213,6 +241,44 @@ describe("presenter notes: instructor endpoint", () => {
     expect(res.body.items[0].questionIndex).toBe(0);
     expect(res.body.items[0].notes[0].bodyHtml).toContain("only the presenter sees this");
     expect(res.body.items[3].notes).toEqual([]);
+  });
+
+  it("allows a deck to disable globally enabled presenter notes", async () => {
+    const { dir, week } = writeTempDeck(DECK_WITH_NOTES_DISABLED);
+    const app = createApp({ quizDir: dir, presenterNotes: true, presenterNotesDefaultOpen: true });
+    const agent = await authedAgent(app);
+    const res = await agent.get(`/api/deck/${week}/presenter-notes`);
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ enabled: false, defaultOpen: false, items: [] });
+    expect(JSON.stringify(res.body)).not.toContain("only the presenter sees this");
+  });
+
+  it("allows a deck to override the global default-open setting", async () => {
+    const contents = DECK_WITH_NOTES.replace(
+      "# Presenter Notes Deck",
+      `# Presenter Notes Deck
+presenter_notes_default_open: false`,
+    );
+    const { dir, week } = writeTempDeck(contents);
+    const app = createApp({ quizDir: dir, presenterNotes: true, presenterNotesDefaultOpen: true });
+    const agent = await authedAgent(app);
+    const res = await agent.get(`/api/deck/${week}/presenter-notes`);
+    expect(res.status).toBe(200);
+    expect(res.body.enabled).toBe(true);
+    expect(res.body.defaultOpen).toBe(false);
+  });
+
+  it("does not let a deck enable notes when the global privacy gate is off", async () => {
+    const contents = DECK_WITH_NOTES.replace(
+      "# Presenter Notes Deck",
+      `# Presenter Notes Deck
+presenter_notes: true`,
+    );
+    const { dir, week } = writeTempDeck(contents);
+    const app = createApp({ quizDir: dir, presenterNotes: false });
+    const agent = await authedAgent(app);
+    const res = await agent.get(`/api/deck/${week}/presenter-notes`);
+    expect(res.body).toEqual({ enabled: false, defaultOpen: false, items: [] });
   });
 
   it("404s for an unknown deck when enabled (authed)", async () => {

--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -552,11 +552,20 @@ export function createApp(quizDirOrOpts?: string | AppOptions) {
     if (!quiz) {
       return res.status(404).json({ error: `Deck not found: ${req.params.week}` });
     }
+    // A deck may opt out of a globally enabled notes feature. It cannot opt in
+    // when the global privacy gate or instructor authentication is unavailable.
+    if (quiz.presenterNotes === false) {
+      return res.json({ enabled: false, defaultOpen: false, items: [] });
+    }
     const items = quiz.questions.map((question, index) => ({
       questionIndex: question.index ?? index,
       notes: question.presenterNotes ?? [],
     }));
-    return res.json({ enabled: true, defaultOpen: presenterNotesDefaultOpen, items });
+    return res.json({
+      enabled: true,
+      defaultOpen: quiz.presenterNotesDefaultOpen ?? presenterNotesDefaultOpen,
+      items,
+    });
   };
   app.get(API.DECK_PRESENTER_NOTES, requireInstructorAuth, getPresenterNotesHandler);
 

--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -1,6 +1,6 @@
 import express, { type Request, type Response } from "express";
 import cors from "cors";
-import { API, AccessInfo, Quiz, Session, SessionState } from "@mdq/shared";
+import { API, AccessInfo, DeckTheme, Quiz, Session, SessionState } from "@mdq/shared";
 import {
   createSession,
   storeSession,
@@ -46,11 +46,16 @@ export interface AppOptions {
   onStateChange?: (session: Session, sessionId: string, newState: SessionState, quiz?: Quiz) => void;
 }
 
-function summarizeQuizForList(q: Quiz) {
+function resolveDeckTheme(q: Quiz, fallbackTheme: DeckTheme): DeckTheme {
+  return q.theme ?? fallbackTheme;
+}
+
+function summarizeQuizForList(q: Quiz, fallbackTheme: DeckTheme) {
   const slideCount = q.questions.filter((question) => question.questionType === "slide").length;
   return {
     week: q.week,
     title: q.title,
+    theme: resolveDeckTheme(q, fallbackTheme),
     questionCount: q.questions.length,
     liveQuestionCount: q.questions.length - slideCount,
     slideCount,
@@ -495,7 +500,7 @@ export function createApp(quizDirOrOpts?: string | AppOptions) {
     if (validationMessage) {
       return res.status(409).json({ error: validationMessage });
     }
-    const list = [...quizzes.values()].sort(compareDecksForList).map(summarizeQuizForList);
+    const list = [...quizzes.values()].sort(compareDecksForList).map((quiz) => summarizeQuizForList(quiz, theme));
     return res.json(list);
   };
 
@@ -509,7 +514,7 @@ export function createApp(quizDirOrOpts?: string | AppOptions) {
       if (validationMessage) {
         return res.status(409).json({ error: validationMessage });
       }
-      const list = [...quizzes.values()].sort(compareDecksForList).map(summarizeQuizForList);
+      const list = [...quizzes.values()].sort(compareDecksForList).map((quiz) => summarizeQuizForList(quiz, theme));
       return res.json({ loaded, quizzes: list });
     } catch (e) {
       const message = e instanceof Error ? e.message : "Failed to reload decks";
@@ -530,6 +535,7 @@ export function createApp(quizDirOrOpts?: string | AppOptions) {
     res.json({
       week: quiz.week,
       title: quiz.title,
+      theme: resolveDeckTheme(quiz, theme),
       questionCount: quiz.questions.length,
     });
   };
@@ -590,6 +596,7 @@ export function createApp(quizDirOrOpts?: string | AppOptions) {
       sessionId: session.sessionId,
       sessionCode: session.sessionCode,
       joinUrl: `/join/${session.sessionCode}`,
+      theme: resolveDeckTheme(quiz, theme),
       questionHeadings: getQuestionHeadings(quiz),
       questionSummaries: getQuestionSummaries(quiz),
     });
@@ -602,11 +609,13 @@ export function createApp(quizDirOrOpts?: string | AppOptions) {
     if (!session) {
       return res.status(404).json({ error: "Session not found for that code" });
     }
+    const quiz = getQuizForSession(session.week);
     res.json({
       sessionId: session.sessionId,
       sessionCode: session.sessionCode,
       state: session.state,
       week: session.week,
+      theme: quiz ? resolveDeckTheme(quiz, theme) : theme,
     });
   });
 
@@ -625,6 +634,7 @@ export function createApp(quizDirOrOpts?: string | AppOptions) {
         sessionId: session.sessionId,
         sessionCode: session.sessionCode,
         week: session.week,
+        theme: resolveDeckTheme(quiz, theme),
         state: session.state,
         currentQuestionIndex: session.currentQuestionIndex,
         questionCount: quiz.questions.length,
@@ -966,6 +976,7 @@ export function createApp(quizDirOrOpts?: string | AppOptions) {
       sessionId: session.sessionId,
       sessionCode: session.sessionCode,
       week: session.week,
+      theme: resolveDeckTheme(quiz, theme),
       state: session.state,
       questionCount: quiz.questions.length,
       questionHeadings: getQuestionHeadings(quiz),

--- a/packages/server/src/parser.ts
+++ b/packages/server/src/parser.ts
@@ -10,6 +10,7 @@ import {
   SlideLiveEmbed,
   SlideVideo,
   SlideReference,
+  DeckTheme,
 } from "@mdq/shared";
 import { marked } from "marked";
 
@@ -57,6 +58,7 @@ export function parseQuizMarkdown(markdown: string, sourceFile: string): ParseRe
   const errors: QuizParseError[] = [];
 
   const title = extractDeckTitle(markdown);
+  const theme = extractDeckThemeMetadata(markdown, sourceFile, errors);
   const presenterNotes = extractDeckBooleanMetadata(markdown, "presenter_notes", sourceFile, errors);
   const presenterNotesDefaultOpen = extractDeckBooleanMetadata(
     markdown,
@@ -99,6 +101,7 @@ export function parseQuizMarkdown(markdown: string, sourceFile: string): ParseRe
   const quiz: Quiz = {
     week,
     title,
+    theme,
     presenterNotes,
     presenterNotesDefaultOpen,
     questions,
@@ -161,6 +164,30 @@ function stripOptionalQuotes(value: string): string {
     return trimmed.slice(1, -1).trim();
   }
   return trimmed;
+}
+
+function extractDeckThemeMetadata(
+  markdown: string,
+  sourceFile: string,
+  errors: QuizParseError[],
+): DeckTheme | undefined {
+  const preamble = markdown.split(/^---+\s*$/m, 1)[0] || markdown;
+  const match = preamble.match(/^theme:\s*(.*?)\s*$/im);
+  if (!match) return undefined;
+
+  const value = stripOptionalQuotes(match[1]).toLowerCase();
+  if (value === "dark" || value === "light") return value;
+
+  const lineNumber = preamble.slice(0, match.index).split("\n").length;
+  errors.push(
+    new QuizParseError(
+      sourceFile,
+      -1,
+      `Invalid theme: ${match[1].trim()} (expected dark or light)`,
+      lineNumber,
+    ),
+  );
+  return undefined;
 }
 
 function extractDeckBooleanMetadata(

--- a/packages/server/src/parser.ts
+++ b/packages/server/src/parser.ts
@@ -57,6 +57,13 @@ export function parseQuizMarkdown(markdown: string, sourceFile: string): ParseRe
   const errors: QuizParseError[] = [];
 
   const title = extractDeckTitle(markdown);
+  const presenterNotes = extractDeckBooleanMetadata(markdown, "presenter_notes", sourceFile, errors);
+  const presenterNotesDefaultOpen = extractDeckBooleanMetadata(
+    markdown,
+    "presenter_notes_default_open",
+    sourceFile,
+    errors,
+  );
 
   // Extract deck key from filename (e.g., "week01.md" -> "week01", "featured-demo.md" -> "featured-demo")
   const sourceStem = sourceFile.replace(/^.*[\\/]/, "").replace(/\.md$/i, "").toLowerCase();
@@ -92,6 +99,8 @@ export function parseQuizMarkdown(markdown: string, sourceFile: string): ParseRe
   const quiz: Quiz = {
     week,
     title,
+    presenterNotes,
+    presenterNotesDefaultOpen,
     questions,
     sourceFile,
   };
@@ -152,6 +161,32 @@ function stripOptionalQuotes(value: string): string {
     return trimmed.slice(1, -1).trim();
   }
   return trimmed;
+}
+
+function extractDeckBooleanMetadata(
+  markdown: string,
+  key: "presenter_notes" | "presenter_notes_default_open",
+  sourceFile: string,
+  errors: QuizParseError[],
+): boolean | undefined {
+  const preamble = markdown.split(/^---+\s*$/m, 1)[0] || markdown;
+  const match = preamble.match(new RegExp(`^${key}:\\s*(.*?)\\s*$`, "im"));
+  if (!match) return undefined;
+
+  const value = stripOptionalQuotes(match[1]).toLowerCase();
+  if (value === "true") return true;
+  if (value === "false") return false;
+
+  const lineNumber = preamble.slice(0, match.index).split("\n").length;
+  errors.push(
+    new QuizParseError(
+      sourceFile,
+      -1,
+      `Invalid ${key}: ${match[1].trim()} (expected true or false)`,
+      lineNumber,
+    ),
+  );
+  return undefined;
 }
 
 /**

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -78,6 +78,7 @@ export interface StudentRejectedPayload {
 }
 
 export type QuestionType = "multiple_choice" | "poll" | "open_response" | "slide";
+export type DeckTheme = "dark" | "light";
 
 export interface FoldoutNote {
   id: string;
@@ -308,6 +309,8 @@ export interface Question {
 export interface Quiz {
   week: string;
   title: string;
+  /** Optional per-deck color theme. The runtime theme remains the fallback. */
+  theme?: DeckTheme;
   /** Optional per-deck override. `false` disables globally enabled presenter notes. */
   presenterNotes?: boolean;
   /** Optional per-deck override for the panel's initial expanded state. */

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -308,6 +308,10 @@ export interface Question {
 export interface Quiz {
   week: string;
   title: string;
+  /** Optional per-deck override. `false` disables globally enabled presenter notes. */
+  presenterNotes?: boolean;
+  /** Optional per-deck override for the panel's initial expanded state. */
+  presenterNotesDefaultOpen?: boolean;
   questions: Question[];
   sourceFile: string;
 }


### PR DESCRIPTION
Decks can now declare `theme: light` or `theme: dark` in their Markdown preamble. Instructor, student, join, reconnect, and projector flows use the deck theme consistently, while decks without an override retain the global runtime theme.

This also restores the per-deck presenter-note overrides from #40, which were merged into an already-merged feature branch and therefore never reached `main`.

### Validated already:

- All 14 server suites pass: 252/252 tests.
- TypeScript typecheck and ESLint pass.
- The production client/server/shared build succeeds.
- Theme parsing, global fallback, session delivery, join-page preload, and reconnect persistence have regression coverage.